### PR TITLE
Add CPU Feature Support

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -68,7 +68,7 @@ fn main() {
         let compiler = build.get_compiler();
 
         if cfg!(target_arch = "i686") || cfg!(target_arch = "x86_64") {
-            let features = x86::Features::get();
+            let features = x86::Features::get_target();
             if compiler.is_like_clang() || compiler.is_like_gnu() {
                 build.flag("-pthread");
 
@@ -119,11 +119,6 @@ fn main() {
         llama_cpp.define("__BSD_VISIBLE", None);
     }
 
-    if let Some(ggml_cuda) = ggml_cuda {
-        println!("compiling ggml-cuda");
-        ggml_cuda.compile("ggml-cuda");
-    }
-
     if cfg!(target_os = "linux") {
         ggml.define("_GNU_SOURCE", None);
     }
@@ -139,6 +134,21 @@ fn main() {
         .define("_XOPEN_SOURCE", Some("600"))
         .std("c++17")
         .file("llama.cpp/llama.cpp");
+
+    // Remove debug log output from `llama.cpp`
+    let is_release = env::var("PROFILE").unwrap() == "release";
+    if is_release {
+        ggml.define("NDEBUG", None);
+        llama_cpp.define("NDEBUG", None);
+        if let Some(cuda) = ggml_cuda.as_mut() {
+            cuda.define("NDEBUG", None);
+        }
+    }
+
+    if let Some(ggml_cuda) = ggml_cuda {
+        println!("compiling ggml-cuda");
+        ggml_cuda.compile("ggml-cuda");
+    }
 
     println!("compiling ggml");
     ggml.compile("ggml");
@@ -185,25 +195,6 @@ mod x86 {
         pub sse3: bool,
     }
     impl Features {
-        pub fn get() -> Self {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            if std::env::var("HOST") == std::env::var("TARGET") {
-                return Self::get_host();
-            }
-
-            Self::get_target()
-        }
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        pub fn get_host() -> Self {
-            Self {
-                fma: std::is_x86_feature_detected!("fma"),
-                avx: std::is_x86_feature_detected!("avx"),
-                avx2: std::is_x86_feature_detected!("avx2"),
-                f16c: std::is_x86_feature_detected!("f16c"),
-                sse3: std::is_x86_feature_detected!("sse3"),
-            }
-        }
 
         pub fn get_target() -> Self {
             let features = crate::get_supported_target_features();

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -11,16 +11,17 @@ fn main() {
         panic!("llama.cpp seems to not be populated, try running `git submodule update --init --recursive` to init.")
     }
 
+    let mut llama_cpp = cc::Build::new();
     let mut ggml = cc::Build::new();
     let mut ggml_cuda = if cublas_enabled {
         Some(cc::Build::new())
     } else {
         None
     };
-    let mut llama_cpp = cc::Build::new();
 
     ggml.cpp(false);
     llama_cpp.cpp(true);
+
 
     // https://github.com/ggerganov/llama.cpp/blob/a836c8f534ab789b02da149fbdaf7735500bff74/Makefile#L364-L368
     if let Some(ggml_cuda) = &mut ggml_cuda {
@@ -61,6 +62,53 @@ fn main() {
         ggml.define("GGML_USE_CUBLAS", None);
         ggml_cuda.define("GGML_USE_CUBLAS", None);
         llama_cpp.define("GGML_USE_CUBLAS", None);
+    }
+
+    for build in [&mut ggml, &mut llama_cpp] {
+        let compiler = build.get_compiler();
+
+        if cfg!(target_arch = "i686") || cfg!(target_arch = "x86_64") {
+            let features = x86::Features::get();
+            if compiler.is_like_clang() || compiler.is_like_gnu() {
+                build.flag("-pthread");
+
+                if features.avx {
+                    build.flag("-mavx");
+                }
+                if features.avx2 {
+                    build.flag("-mavx2");
+                }
+                if features.fma {
+                    build.flag("-mfma");
+                }
+                if features.f16c {
+                    build.flag("-mf16c");
+                }
+                if features.sse3 {
+                    build.flag("-msse3");
+                }
+            } else if compiler.is_like_msvc() {
+                match (features.avx2, features.avx) {
+                    (true, _) => {
+                        build.flag("/arch:AVX2");
+                    }
+                    (_, true) => {
+                        build.flag("/arch:AVX");
+                    }
+                    _ => {}
+                }
+            }
+        } else if cfg!(target_arch = "aarch64") {
+            if compiler.is_like_clang() || compiler.is_like_gnu() {
+                if cfg!(target_os = "macos") {
+                    build.flag("-mcpu=apple-m1");
+                } else if std::env::var("HOST") == std::env::var("TARGET") {
+                    build.flag("-mcpu=native");
+                    build.flag("-mfpu=neon");
+                }
+                build.flag("-pthread");
+            }
+        }
     }
 
     // https://github.com/ggerganov/llama.cpp/blob/191221178f51b6e81122c5bda0fd79620e547d07/Makefile#L133-L141
@@ -115,4 +163,57 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("failed to write bindings to file");
+}
+
+// Courtesy of the `llm` crate's build.rs
+fn get_supported_target_features() -> std::collections::HashSet<String> {
+    env::var("CARGO_CFG_TARGET_FEATURE")
+        .unwrap()
+        .split(',')
+        .map(ToString::to_string)
+        .collect()
+}
+
+mod x86 {
+    #[allow(clippy::struct_excessive_bools)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct Features {
+        pub fma: bool,
+        pub avx: bool,
+        pub avx2: bool,
+        pub f16c: bool,
+        pub sse3: bool,
+    }
+    impl Features {
+        pub fn get() -> Self {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            if std::env::var("HOST") == std::env::var("TARGET") {
+                return Self::get_host();
+            }
+
+            Self::get_target()
+        }
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        pub fn get_host() -> Self {
+            Self {
+                fma: std::is_x86_feature_detected!("fma"),
+                avx: std::is_x86_feature_detected!("avx"),
+                avx2: std::is_x86_feature_detected!("avx2"),
+                f16c: std::is_x86_feature_detected!("f16c"),
+                sse3: std::is_x86_feature_detected!("sse3"),
+            }
+        }
+
+        pub fn get_target() -> Self {
+            let features = crate::get_supported_target_features();
+            Self {
+                fma: features.contains("fma"),
+                avx: features.contains("avx"),
+                avx2: features.contains("avx2"),
+                f16c: features.contains("f16c"),
+                sse3: features.contains("sse3"),
+            }
+        }
+    }
 }

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -108,7 +108,6 @@ fn main() {
                     build.flag("-mcpu=apple-m1");
                 } else if std::env::var("HOST") == std::env::var("TARGET") {
                     build.flag("-mcpu=native");
-                    build.flag("-mfpu=neon");
                 }
                 build.flag("-pthread");
             }


### PR DESCRIPTION
This PR will ensure SIMD implementations will be used by GGML when the _target_ supports them.

Mostly taken from the `llm` crate. If you want to verify whether it worked you can simply use `llama_cpp_sys_2::llama_print_system_info()`

Note that you'll need to specify a target which has the features available, e.g. `-Ctarget-cpu=ivybridge` to enable AVX only. The base x86_64 target in Rustc has _no_ SIMD features available at the moment.
