### PR TITLE
Add Embedding Related Functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "embeddings"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hf-hub",
+ "llama-cpp-2",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "llama-cpp-sys-2",
     "llama-cpp-2",
-    "simple",
+    "simple", "embeddings",
 ]
 
 [workspace.dependencies]

--- a/embeddings/Cargo.toml
+++ b/embeddings/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "embeddings"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+llama-cpp-2 = { path = "../llama-cpp-2", version = "0.1.34" }
+hf-hub = { workspace = true }
+clap = { workspace = true , features = ["derive"] }
+anyhow = { workspace = true }
+
+[lints]
+workspace = true

--- a/embeddings/src/main.rs
+++ b/embeddings/src/main.rs
@@ -52,9 +52,9 @@ enum Model {
     /// Download a model from huggingface (or use a cached version)
     #[clap(name = "hf-model")]
     HuggingFace {
-        /// the repo containing the model. e.g. `TheBloke/Llama-2-7B-Chat-GGUF`
+        /// the repo containing the model. e.g. `BAAI/bge-small-en-v1.5`
         repo: String,
-        /// the model name. e.g. `llama-2-7b-chat.Q4_K_M.gguf`
+        /// the model name. e.g. `BAAI-bge-small-v1.5.Q4_K_M.gguf`
         model: String,
     },
 }
@@ -147,7 +147,7 @@ fn main() -> Result<()> {
 
     // create a llama_batch with the size of the context
     // we use this object to submit token data for decoding
-    let mut batch = LlamaBatch::new(n_ctx, tokens_lines_list.len() as i32);
+    let mut batch = LlamaBatch::new(n_ctx, 1);
 
     // Amount of tokens in the current batch
     let mut s_batch = 0;

--- a/embeddings/src/main.rs
+++ b/embeddings/src/main.rs
@@ -1,0 +1,216 @@
+//! This is a translation of embedding.cpp in llama.cpp using llama-cpp-2.
+#![allow(
+clippy::cast_possible_wrap,
+clippy::cast_possible_truncation,
+clippy::cast_precision_loss,
+clippy::cast_sign_loss
+)]
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use hf_hub::api::sync::ApiBuilder;
+use llama_cpp_2::context::LlamaContext;
+
+use llama_cpp_2::context::params::LlamaContextParams;
+use llama_cpp_2::ggml_time_us;
+use llama_cpp_2::llama_backend::LlamaBackend;
+use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::model::AddBos;
+use llama_cpp_2::model::LlamaModel;
+use llama_cpp_2::model::params::LlamaModelParams;
+
+#[derive(clap::Parser, Debug, Clone)]
+struct Args {
+    /// The path to the model
+    #[command(subcommand)]
+    model: Model,
+    /// The prompt
+    #[clap(default_value = "Hello my name is")]
+    prompt: String,
+    /// Whether to normalise the produced embeddings
+    #[clap(short)]
+    normalise: bool,
+    /// Disable offloading layers to the gpu
+    #[cfg(feature = "cublas")]
+    #[clap(long)]
+    disable_gpu: bool,
+}
+
+
+#[derive(clap::Subcommand, Debug, Clone)]
+enum Model {
+    /// Use an already downloaded model
+    Local {
+        /// The path to the model. e.g. `/home/marcus/.cache/huggingface/hub/models--TheBloke--Llama-2-7B-Chat-GGUF/blobs/08a5566d61d7cb6b420c3e4387a39e0078e1f2fe5f055f3a03887385304d4bfa`
+        path: PathBuf,
+    },
+    /// Download a model from huggingface (or use a cached version)
+    #[clap(name = "hf-model")]
+    HuggingFace {
+        /// the repo containing the model. e.g. `TheBloke/Llama-2-7B-Chat-GGUF`
+        repo: String,
+        /// the model name. e.g. `llama-2-7b-chat.Q4_K_M.gguf`
+        model: String,
+    },
+}
+
+impl Model {
+    /// Convert the model to a path - may download from huggingface
+    fn get_or_load(self) -> Result<PathBuf> {
+        match self {
+            Model::Local { path } => Ok(path),
+            Model::HuggingFace { model, repo } => ApiBuilder::new()
+                .with_progress(true)
+                .build()
+                .with_context(|| "unable to create huggingface api")?
+                .model(repo)
+                .get(&model)
+                .with_context(|| "unable to download model"),
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let Args {
+        model,
+        prompt,
+        normalise,
+        #[cfg(feature = "cublas")]
+        disable_gpu,
+    } = Args::parse();
+
+    // init LLM
+    let backend = LlamaBackend::init()?;
+
+    // offload all layers to the gpu
+    let model_params = {
+        #[cfg(feature = "cublas")]
+        if !disable_gpu {
+            LlamaModelParams::default().with_n_gpu_layers(1000)
+        } else {
+            LlamaModelParams::default()
+        }
+        #[cfg(not(feature = "cublas"))]
+        LlamaModelParams::default()
+    };
+
+    let model_path = model
+        .get_or_load()
+        .with_context(|| "failed to get model from args")?;
+
+    let model = LlamaModel::load_from_file(&backend, model_path, &model_params)
+        .with_context(|| "unable to load model")?;
+
+    // initialize the context
+    let ctx_params = LlamaContextParams::default()
+        .with_n_threads_batch(std::thread::available_parallelism()?.get() as u32)
+        .with_embedding(true);
+
+    let mut ctx = model
+        .new_context(&backend, ctx_params)
+        .with_context(|| "unable to create the llama_context")?;
+
+    // Split the prompt to display the batching functionality
+    let prompt_lines = prompt.lines();
+
+    // tokenize the prompt
+    let tokens_lines_list = prompt_lines.map(|line| model.str_to_token(&line, AddBos::Always))
+        .collect::<Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to tokenize {prompt}"))?;
+
+    let n_ctx = ctx.n_ctx() as usize;
+    let n_ctx_train = model.n_ctx_train();
+
+    eprintln!("n_ctx = {n_ctx}, n_ctx_train = {n_ctx_train}");
+
+    if tokens_lines_list.iter().any(|tok| n_ctx < tok.len()) {
+        bail!("One of the provided prompts exceeds the size of the context window");
+    }
+
+    // print the prompt token-by-token
+    eprintln!();
+
+    for (i, token_line) in tokens_lines_list.iter().enumerate() {
+        eprintln!("Prompt {i}");
+        for token in token_line {
+            eprintln!(" {} --> {}", token, model.token_to_str(*token)?);
+        }
+        eprintln!()
+    }
+
+    std::io::stderr().flush()?;
+
+    // create a llama_batch with the size of the context
+    // we use this object to submit token data for decoding
+    let mut batch = LlamaBatch::new(n_ctx, tokens_lines_list.len() as i32);
+
+    // Amount of tokens in the current batch
+    let mut s_batch = 0;
+    let mut output = Vec::with_capacity(tokens_lines_list.len());
+
+    let t_main_start = ggml_time_us();
+
+    for tokens in &tokens_lines_list {
+        // Flush the batch if the next prompt would exceed our batch size
+        if (batch.n_tokens() as usize + tokens.len()) > n_ctx {
+            batch_decode(&mut ctx, &mut batch, s_batch, &mut output, normalise)?;
+            s_batch = 0;
+        }
+
+        batch.add_sequence(&tokens, s_batch, false)?;
+        s_batch += 1;
+    }
+    // Handle final batch
+    batch_decode(&mut ctx, &mut batch, s_batch, &mut output, normalise)?;
+
+    let t_main_end = ggml_time_us();
+
+    for (i, embeddings) in output.iter().enumerate() {
+        eprintln!("Embeddings {i}: {embeddings:?}");
+        eprintln!("\n");
+    }
+
+    let duration = Duration::from_micros((t_main_end - t_main_start) as u64);
+    let total_tokens: usize = tokens_lines_list.iter().map(|v| v.len()).sum();
+
+    eprintln!(
+        "Created embeddings for {} tokens in {:.2} s, speed {:.2} t/s\n",
+        total_tokens,
+        duration.as_secs_f32(),
+        total_tokens as f32 / duration.as_secs_f32()
+    );
+
+    println!("{}", ctx.timings());
+
+    Ok(())
+}
+
+fn batch_decode(ctx: &mut LlamaContext, batch: &mut LlamaBatch, s_batch: i32, output: &mut Vec<Vec<f32>>, normalise: bool) -> Result<()> {
+    ctx.clear_kv_cache();
+    ctx.decode(batch).with_context(|| "llama_decode() failed")?;
+    batch.clear();
+
+    for i in 0..s_batch {
+        let embedding = ctx.embeddings_ith(i).with_context(|| "Failed to get embeddings")?;
+        let output_embeddings = if normalise {
+            normalize(embedding)
+        } else {
+            embedding.to_vec()
+        };
+
+        output.push(output_embeddings);
+    }
+
+    Ok(())
+}
+
+fn normalize(input: &[f32]) -> Vec<f32> {
+    let magnitude = input.iter().fold(0.0, |acc, &val| val.mul_add(val, acc)).sqrt();
+
+    input.iter().map(|&val| val / magnitude).collect()
+}

--- a/embeddings/src/main.rs
+++ b/embeddings/src/main.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
     // initialize the context
     let ctx_params = LlamaContextParams::default()
         .with_n_threads_batch(std::thread::available_parallelism()?.get() as u32)
-        .with_embedding(true);
+        .with_embeddings(true);
 
     let mut ctx = model
         .new_context(&backend, ctx_params)
@@ -193,10 +193,9 @@ fn main() -> Result<()> {
 fn batch_decode(ctx: &mut LlamaContext, batch: &mut LlamaBatch, s_batch: i32, output: &mut Vec<Vec<f32>>, normalise: bool) -> Result<()> {
     ctx.clear_kv_cache();
     ctx.decode(batch).with_context(|| "llama_decode() failed")?;
-    batch.clear();
 
     for i in 0..s_batch {
-        let embedding = ctx.embeddings_ith(i).with_context(|| "Failed to get embeddings")?;
+        let embedding = ctx.embeddings_seq_ith(i).with_context(|| "Failed to get embeddings")?;
         let output_embeddings = if normalise {
             normalize(embedding)
         } else {
@@ -205,6 +204,8 @@ fn batch_decode(ctx: &mut LlamaContext, batch: &mut LlamaBatch, s_batch: i32, ou
 
         output.push(output_embeddings);
     }
+
+    batch.clear();
 
     Ok(())
 }

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -189,11 +189,6 @@ impl<'model> LlamaContext<'model> {
         let timings = unsafe { llama_cpp_sys_2::llama_get_timings(self.context.as_ptr()) };
         LlamaTimings { timings }
     }
-
-    /// Returns a reference to the raw [llama_cpp_sys_2::llama_context] pointer.
-    pub fn raw_ctx(&self) -> &NonNull<llama_cpp_sys_2::llama_context> {
-        &self.context
-    }
 }
 
 impl Drop for LlamaContext<'_> {

--- a/llama-cpp-2/src/context/params.rs
+++ b/llama-cpp-2/src/context/params.rs
@@ -1,7 +1,8 @@
 //! A safe wrapper around `llama_context_params`.
-use llama_cpp_sys_2;
 use std::fmt::Debug;
 use std::num::NonZeroU32;
+
+use llama_cpp_sys_2;
 
 /// A rusty wrapper around `rope_scaling_type`.
 #[repr(i8)]
@@ -267,6 +268,19 @@ impl LlamaContextParams {
         self.context_params.n_threads
     }
 
+    /// Get the number of threads allocated for batches.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let params = llama_cpp_2::context::params::LlamaContextParams::default();
+    /// assert_eq!(params.n_threads_batch(), 4);
+    /// ```
+    #[must_use]
+    pub fn n_threads_batch(&self) -> u32 {
+        self.context_params.n_threads_batch
+    }
+
     /// Set the number of threads.
     ///
     /// # Examples
@@ -280,6 +294,51 @@ impl LlamaContextParams {
     #[must_use]
     pub fn with_n_threads(mut self, n_threads: u32) -> Self {
         self.context_params.n_threads = n_threads;
+        self
+    }
+
+    /// Set the number of threads allocated for batches.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use llama_cpp_2::context::params::LlamaContextParams;
+    /// let params = LlamaContextParams::default()
+    ///    .with_n_threads_batch(8);
+    /// assert_eq!(params.n_threads_batch(), 8);
+    /// ```
+    #[must_use]
+    pub fn with_n_threads_batch(mut self, n_threads: u32) -> Self {
+        self.context_params.n_threads_batch = n_threads;
+        self
+    }
+
+    /// Check whether embeddings are enabled
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let params = llama_cpp_2::context::params::LlamaContextParams::default();
+    /// assert!(!params.embedding());
+    /// ```
+    #[must_use]
+    pub fn embedding(&self) -> bool {
+        self.context_params.embedding
+    }
+
+    /// Enable the use of embeddings
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use llama_cpp_2::context::params::LlamaContextParams;
+    /// let params = LlamaContextParams::default()
+    ///    .with_embedding(true);
+    /// assert!(params.embedding());
+    /// ```
+    #[must_use]
+    pub fn with_embedding(mut self, embedding: bool) -> Self {
+        self.context_params.embedding = embedding;
         self
     }
 }

--- a/llama-cpp-2/src/context/params.rs
+++ b/llama-cpp-2/src/context/params.rs
@@ -319,11 +319,11 @@ impl LlamaContextParams {
     ///
     /// ```rust
     /// let params = llama_cpp_2::context::params::LlamaContextParams::default();
-    /// assert!(!params.embedding());
+    /// assert!(!params.embeddings());
     /// ```
     #[must_use]
-    pub fn embedding(&self) -> bool {
-        self.context_params.embedding
+    pub fn embeddings(&self) -> bool {
+        self.context_params.embeddings
     }
 
     /// Enable the use of embeddings
@@ -333,12 +333,12 @@ impl LlamaContextParams {
     /// ```rust
     /// use llama_cpp_2::context::params::LlamaContextParams;
     /// let params = LlamaContextParams::default()
-    ///    .with_embedding(true);
-    /// assert!(params.embedding());
+    ///    .with_embeddings(true);
+    /// assert!(params.embeddings());
     /// ```
     #[must_use]
-    pub fn with_embedding(mut self, embedding: bool) -> Self {
-        self.context_params.embedding = embedding;
+    pub fn with_embeddings(mut self, embedding: bool) -> Self {
+        self.context_params.embeddings = embedding;
         self
     }
 }

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -52,6 +52,8 @@ pub enum LLamaCppError {
     /// There was an error adding a token to a batch.
     #[error["{0}"]]
     BatchAddError(#[from] BatchAddError),
+    #[error(transparent)]
+    EmbeddingError(#[from] EmbeddingsError),
 }
 
 /// Failed to Load context
@@ -74,6 +76,13 @@ pub enum DecodeError {
     /// An unknown error occurred.
     #[error("Decode Error {0}: unknown")]
     Unknown(c_int),
+}
+
+/// When embedding related functions fail
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum EmbeddingsError {
+    #[error("Embeddings weren't enabled in the context options")]
+    NotEnabled,
 }
 
 /// Decode a error from llama.cpp into a [`DecodeError`].

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -83,6 +83,10 @@ pub enum DecodeError {
 pub enum EmbeddingsError {
     #[error("Embeddings weren't enabled in the context options")]
     NotEnabled,
+    #[error("Logits were not enabled for the given token")]
+    LogitsNotEnabled,
+    #[error("Can't use sequence embeddings with a model supporting only LLAMA_POOLING_TYPE_NONE")]
+    NonePoolType,
 }
 
 /// Decode a error from llama.cpp into a [`DecodeError`].

--- a/llama-cpp-2/src/llama_backend.rs
+++ b/llama-cpp-2/src/llama_backend.rs
@@ -3,6 +3,7 @@
 use crate::LLamaCppError;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;
+use llama_cpp_sys_2::ggml_log_level;
 
 /// Representation of an initialized llama backend
 /// This is required as a parameter for most llama functions as the backend must be initialized
@@ -67,6 +68,19 @@ impl LlamaBackend {
             llama_cpp_sys_2::llama_numa_init(llama_cpp_sys_2::ggml_numa_strategy::from(strategy));
         }
         Ok(LlamaBackend {})
+    }
+
+    /// Change the output of llama.cpp's logging to be voided instead of pushed to `stderr`.
+    pub fn void_logs(&mut self) {
+        unsafe extern "C" fn void_log(
+            _level: ggml_log_level,
+            _text: *const ::std::os::raw::c_char,
+            _user_data: *mut ::std::os::raw::c_void,
+        ) {}
+
+        unsafe {
+            llama_cpp_sys_2::llama_log_set(Some(void_log), std::ptr::null_mut())
+        }
     }
 }
 

--- a/llama-cpp-2/src/llama_batch.rs
+++ b/llama-cpp-2/src/llama_batch.rs
@@ -121,14 +121,13 @@ impl LlamaBatch {
                 let seq_id_ptr = *self.llama_batch.seq_id.add(j);
                 seq_id_ptr.write(seq_id);
                 self.llama_batch.n_seq_id.add(j).write(1);
-                self.llama_batch.logits.add(j).write(logits_all as i8)
+
+                let write_logits = logits_all || i == n_tokens - 1;
+                self.llama_batch.logits.add(j).write(write_logits as i8)
             }
         }
 
-        unsafe {
-            self.llama_batch.logits.add(n_tokens - 1).write(true as i8);
-            self.initialized_logits.push(self.llama_batch.n_tokens - 1);
-        }
+        self.initialized_logits.push(self.llama_batch.n_tokens - 1);
 
         Ok(())
     }

--- a/llama-cpp-2/src/llama_batch.rs
+++ b/llama-cpp-2/src/llama_batch.rs
@@ -127,6 +127,7 @@ impl LlamaBatch {
 
         unsafe {
             self.llama_batch.logits.add(n_tokens - 1).write(true as i8);
+            self.initialized_logits.push(self.llama_batch.n_tokens - 1);
         }
 
         Ok(())

--- a/llama-cpp-2/src/llama_batch.rs
+++ b/llama-cpp-2/src/llama_batch.rs
@@ -123,11 +123,12 @@ impl LlamaBatch {
                 self.llama_batch.n_seq_id.add(j).write(1);
 
                 let write_logits = logits_all || i == n_tokens - 1;
-                self.llama_batch.logits.add(j).write(write_logits as i8)
+                self.llama_batch.logits.add(j).write(write_logits as i8);
+                if write_logits {
+                    self.initialized_logits.push(j as i32);
+                }
             }
         }
-
-        self.initialized_logits.push(self.llama_batch.n_tokens - 1);
 
         Ok(())
     }

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -320,7 +320,7 @@ impl LlamaModel {
         };
         let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
-        Ok(LlamaContext::new(self, context, params.embedding()))
+        Ok(LlamaContext::new(self, context, params.embeddings()))
     }
 }
 

--- a/llama-cpp-2/src/token_type.rs
+++ b/llama-cpp-2/src/token_type.rs
@@ -28,15 +28,15 @@ pub enum LlamaTokenType {
 ///
 /// ```
 /// # use std::convert::TryFrom;
-/// # use std::ffi::c_uint;
+/// # use std::ffi::c_int;
 /// # use std::num::TryFromIntError;
 /// # use std::result::Result;
 /// # use llama_cpp_2::token_type::{LlamaTokenTypeFromIntError, LlamaTokenType};
 /// # fn main() -> Result<(), LlamaTokenTypeFromIntError> {
-/// let llama_token_type = LlamaTokenType::try_from(0 as c_uint)?;
+/// let llama_token_type = LlamaTokenType::try_from(0 as c_int)?;
 /// assert_eq!(llama_token_type, LlamaTokenType::Undefined);
 ///
-/// let bad_llama_token_type = LlamaTokenType::try_from(100 as c_uint);
+/// let bad_llama_token_type = LlamaTokenType::try_from(100 as c_int);
 /// assert_eq!(Err(LlamaTokenTypeFromIntError::UnknownValue(100)), bad_llama_token_type);
 /// # Ok(())
 /// # }

--- a/llama-cpp-2/src/token_type.rs
+++ b/llama-cpp-2/src/token_type.rs
@@ -33,10 +33,10 @@ pub enum LlamaTokenType {
 /// # use std::result::Result;
 /// # use llama_cpp_2::token_type::{LlamaTokenTypeFromIntError, LlamaTokenType};
 /// # fn main() -> Result<(), LlamaTokenTypeFromIntError> {
-/// let llama_token_type = LlamaTokenType::try_from(0 as c_int)?;
+/// let llama_token_type = LlamaTokenType::try_from(0 as llama_cpp_sys_2::llama_token_type)?;
 /// assert_eq!(llama_token_type, LlamaTokenType::Undefined);
 ///
-/// let bad_llama_token_type = LlamaTokenType::try_from(100 as c_int);
+/// let bad_llama_token_type = LlamaTokenType::try_from(100 as llama_cpp_sys_2::llama_token_type);
 /// assert_eq!(Err(LlamaTokenTypeFromIntError::UnknownValue(100)), bad_llama_token_type);
 /// # Ok(())
 /// # }


### PR DESCRIPTION
Recently `llama.cpp` has added the ability to generate embeddings using BERT related models. There have been some issues, namely differences between the embeddings generated in Python and the ones coming from `llama.cpp`, but with https://github.com/ggerganov/llama.cpp/pull/5796 being merged it seems to finally be stable.

This PR implements the functionality to allow a user to make use of these new features, it adds an example based loosely on the `llama.cpp` embeddings example. Most of the code was translated from either `llama.cpp` or `llama-cpp-python` (specifically, the `add_sequence` method in `LLamaBatch`).

A few additional changes snuck in as well, replacing a `println!` call with a `tracing` call to allow users to filter it out, alongside a fix for a failing doc-test.