### PR TITLE
Bump version to 0.1.41

### DIFF
--- a/.github/workflows/update-toml-version.yaml
+++ b/.github/workflows/update-toml-version.yaml
@@ -38,4 +38,4 @@ jobs:
           git checkout -b version-bump-$NEXT_VERSION
           # Push the changes and create a pull request
           git push origin version-bump-$NEXT_VERSION
-          gh pr create --base main --head version-bump-$NEXT_VERSION --title "Bump version to $NEXT_VERSION"
+          gh pr create --base main --head version-bump-$NEXT_VERSION --title "Bump version to $NEXT_VERSION" --fill

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-2"
 description = "llama.cpp bindings for Rust"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"
@@ -9,7 +9,7 @@ repository = "https://github.com/utilityai/llama-cpp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.38" }
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.39" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-2"
 description = "llama.cpp bindings for Rust"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"
@@ -9,7 +9,7 @@ repository = "https://github.com/utilityai/llama-cpp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.39" }
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.40" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-2"
 description = "llama.cpp bindings for Rust"
-version = "0.1.40"
+version = "0.1.41"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"
@@ -9,7 +9,7 @@ repository = "https://github.com/utilityai/llama-cpp-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.40" }
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.41" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-sys-2"
 description = "Low Level Bindings to llama.cpp"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-sys-2"
 description = "Low Level Bindings to llama.cpp"
-version = "0.1.40"
+version = "0.1.41"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-sys-2"
 description = "Low Level Bindings to llama.cpp"
-version = "0.1.38"
+version = "0.1.39"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"


### PR DESCRIPTION
- added --fill when creating the pr in the update toml workflow
- Bump version to 0.1.39 [skip ci]
- Bump version to 0.1.40 [skip ci]
- Bump version to 0.1.41 [skip ci]
