### PR TITLE
Update llama cpp fix

### DIFF
--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - update-llama-cpp-*
   workflow_dispatch:
   repository_dispatch:
     types: [ trigger-llama-cpp-rs-check ]

--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -4,10 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - update-llama-cpp-**
   workflow_dispatch:
-  repository_dispatch:
-    types: [ trigger-llama-cpp-rs-check ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  repository_dispatch:
+    types: [ trigger-llama-cpp-rs-check ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - update-llama-cpp-fix
+      - update-llama-cpp-**
   workflow_dispatch:
   repository_dispatch:
     types: [ trigger-llama-cpp-rs-check ]

--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - update-llama-cpp-*
+      - update-llama-cpp-fix
   workflow_dispatch:
   repository_dispatch:
     types: [ trigger-llama-cpp-rs-check ]

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --head update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)"
+          gh pr create --fill --head update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)" --body "Please close and reopen the pull request for the checks to trigger."

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -2,7 +2,7 @@ name: Update llama cpp nightly
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: { }
+  workflow_dispatch: {}
 
 permissions:
   pull-requests: write
@@ -36,15 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr list --json number,title --jq '.[] | select(.title | contains("Update llama-cpp")) | .number' | xargs -I {} gh pr close {}
-      - name: Create open PR
+      - name: create draft pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Update llama-cpp"
-      - name: Dispatch update-llama-cpp-rs-check
-        run: |
-          curl -X POST \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github.everest-preview+json" \
-          "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          -d '{"event_type": "trigger-llama-cpp-rs-check"}'
-
+          gh pr create --fill --draft --body "please close and reopen this pull request to trigger the checks"

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -35,8 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --json number,title --jq '.[] | select(.title | contains("Updated llama-cpp-${{ env.DATE }}")) | .number' | xargs -I {} gh pr close {}
+          gh pr list --json number,title --jq '.[] | select(.title | contains("Updated llama-cpp (bot)")) | .number' | xargs -I {} gh pr close {}
       - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp-${{ env.DATE }}"
+          gh pr create --fill update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)"

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -40,11 +40,11 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
           gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Update llama-cpp"
-      - name: Trigger the llama-cpp-rs-check workflow
+      - name: Dispatch update-llama-cpp-rs-check
         run: |
           curl -X POST \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": { "ref": "refs/heads/update-llama-cpp-${{ env.DATE }}" }}'
+          -d '{"event_type": "trigger-llama-cpp-rs-check"}'
 

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)"
+          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)"

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr list --json number,title --jq '.[] | select(.title | contains("Update llama-cpp")) | .number' | xargs -I {} gh pr close {}
-      - name: create draft pr
+      - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --draft --body "please close and reopen this pull request to trigger the checks" --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} 
+          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Update llama-cpp"

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -2,7 +2,7 @@ name: Update llama cpp nightly
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: { }
+  workflow_dispatch: {}
 
 permissions:
   pull-requests: write
@@ -17,11 +17,8 @@ jobs:
         name: Checkout latest
         with:
           submodules: recursive
-      - name: create branch and save branch name
-        run: |
-          BRANCH_NAME=update-llama-cpp-$(date -I)
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-          git checkout -b $BRANCH_NAME
+      - name: create branch
+        run: git checkout -b update-llama-cpp-$(date -I)
       - name: update submodules
         run: git submodule update --remote
       - name: config git
@@ -32,11 +29,11 @@ jobs:
         run: git commit -am "updated llama.cpp"
       - name: push
         run: git push --set-upstream origin $BRANCH_NAME --force
-      - name: close any outdated prs with the same name
+      - name: close any outdated prs with the name update-llama-cpp-$(date -I)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --state open --json number,title | jq -r '.[] | select(.title | contains("'"$BRANCH_NAME"'")) | .number' | xargs -I {} gh pr close {}
+            gh pr list --json state=open --json number --json title | jq -r '.[] | select(.title | contains("update-llama-cpp-$(date -I)")) | .number' | xargs -I {} gh pr close {}
       - name: create open pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -46,4 +46,5 @@ jobs:
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": { "ref": "update-llama-cpp-${{ env.DATE }}" }}'
+          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": { "ref": "refs/heads/update-llama-cpp-${{ env.DATE }}" }}'
+

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -2,7 +2,7 @@ name: Update llama cpp nightly
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch: { }
 
 permissions:
   pull-requests: write
@@ -17,8 +17,11 @@ jobs:
         name: Checkout latest
         with:
           submodules: recursive
-      - name: create branch
-        run: git checkout -b update-llama-cpp-$(date -I)
+      - name: create branch and save branch name
+        run: |
+          BRANCH_NAME=update-llama-cpp-$(date -I)
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          git checkout -b $BRANCH_NAME
       - name: update submodules
         run: git submodule update --remote
       - name: config git
@@ -28,8 +31,21 @@ jobs:
       - name: commit
         run: git commit -am "updated llama.cpp"
       - name: push
-        run: git push --set-upstream origin update-llama-cpp-$(date -I) --force
-      - name: create draft pr
+        run: git push --set-upstream origin $BRANCH_NAME --force
+      - name: close any outdated prs with the same name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list --state open --json number,title | jq -r '.[] | select(.title | contains("'"$BRANCH_NAME"'")) | .number' | xargs -I {} gh pr close {}
+      - name: create open pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --draft --body "please close and reopen this pull request to trigger the checks"
+          gh pr create --fill --open
+      - name: Trigger the llama-cpp-rs-check workflow
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": {"branch": "'"$BRANCH_NAME"'" }}'    
+

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -13,36 +13,37 @@ jobs:
     runs-on: ubuntu-latest
     name: Update llama cpp
     steps:
+      - name: Set date
+        run: echo "DATE=$(date -I)" >> $GITHUB_ENV
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         name: Checkout latest
         with:
           submodules: recursive
-      - name: create branch
-        run: git checkout -b update-llama-cpp-$(date -I)
-      - name: update submodules
+      - name: Create branch
+        run: git checkout -b update-llama-cpp-${{ env.DATE }}
+      - name: Update submodules
         run: git submodule update --remote
-      - name: config git
+      - name: Config git
         run: |
           git config --global user.email "marcus@utilityai.ca"
           git config --global user.name "Marcus Dunn"
-      - name: commit
+      - name: Commit
         run: git commit -am "updated llama.cpp"
-      - name: push
-        run: git push --set-upstream origin  update-llama-cpp-$(date -I) --force
-      - name: close any outdated prs with the name update-llama-cpp-$(date -I)
+      - name: Push
+        run: git push --set-upstream origin update-llama-cpp-${{ env.DATE }} --force
+      - name: Close any outdated PRs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --json state=open --json number --json title | jq -r '.[] | select(.title | contains("Update llama-cpp")) | .number' | xargs -I {} gh pr close {}
-      - name: create open pr
+          gh pr list --json number,title --jq '.[] | select(.title | contains("Update llama-cpp")) | .number' | xargs -I {} gh pr close {}
+      - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-$(date -I) --title "Update llama-cpp"
+          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Update llama-cpp"
       - name: Trigger the llama-cpp-rs-check workflow
         run: |
           curl -X POST \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": { "ref": "update-llama-cpp-$(date -I)" }}'   
-
+          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": { "ref": "update-llama-cpp-${{ env.DATE }}" }}'

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -35,8 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr list --json number,title --jq '.[] | select(.title | contains("Update llama-cpp")) | .number' | xargs -I {} gh pr close {}
+          gh pr list --json number,title --jq '.[] | select(.title | contains("Updated llama-cpp-${{ env.DATE }}")) | .number' | xargs -I {} gh pr close {}
       - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Update llama-cpp"
+          gh pr create --fill update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp-${{ env.DATE }}"

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Create open PR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)"
+          gh pr create --fill --head update-llama-cpp-${{ env.DATE }} --title "Updated llama-cpp (bot)"

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -40,7 +40,7 @@ jobs:
       - name: create open pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill
+          gh pr create --fill --base update-llama-cpp-fix --head $BRANCH_NAME
       - name: Trigger the llama-cpp-rs-check workflow
         run: |
           curl -X POST \

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -2,7 +2,7 @@ name: Update llama cpp nightly
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch: { }
 
 permissions:
   pull-requests: write
@@ -28,21 +28,21 @@ jobs:
       - name: commit
         run: git commit -am "updated llama.cpp"
       - name: push
-        run: git push --set-upstream origin $BRANCH_NAME --force
+        run: git push --set-upstream origin  update-llama-cpp-$(date -I) --force
       - name: close any outdated prs with the name update-llama-cpp-$(date -I)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            gh pr list --json state=open --json number --json title | jq -r '.[] | select(.title | contains("update-llama-cpp-$(date -I)")) | .number' | xargs -I {} gh pr close {}
+          gh pr list --json state=open --json number --json title | jq -r '.[] | select(.title | contains("Update llama-cpp")) | .number' | xargs -I {} gh pr close {}
       - name: create open pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --base update-llama-cpp-fix --head $BRANCH_NAME
+          gh pr create --fill --base update-llama-cpp-fix --head update-llama-cpp-$(date -I) --title "Update llama-cpp"
       - name: Trigger the llama-cpp-rs-check workflow
         run: |
           curl -X POST \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": {"branch": "'"$BRANCH_NAME"'" }}'    
+          -d '{"event_type": "trigger-llama-cpp-rs-check", "client_payload": { "ref": "update-llama-cpp-$(date -I)" }}'   
 

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -40,7 +40,7 @@ jobs:
       - name: create open pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --open
+          gh pr create --fill
       - name: Trigger the llama-cpp-rs-check workflow
         run: |
           curl -X POST \

--- a/.github/workflows/update-llama-cpp.yml
+++ b/.github/workflows/update-llama-cpp.yml
@@ -2,7 +2,7 @@ name: Update llama cpp nightly
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch: { }
 
 permissions:
   pull-requests: write
@@ -39,4 +39,4 @@ jobs:
       - name: create draft pr
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh pr create --fill --draft --body "please close and reopen this pull request to trigger the checks"
+          gh pr create --fill --draft --body "please close and reopen this pull request to trigger the checks" --base update-llama-cpp-fix --head update-llama-cpp-${{ env.DATE }} 

--- a/.github/workflows/update-toml-version.yaml
+++ b/.github/workflows/update-toml-version.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   modify_files:


### PR DESCRIPTION
- Changed the pr type to open instead of draft for update llama cpp 
- Made it so that every pr made by the github action will delete any previously made prs for llama-cpp update