### PR TITLE
Added passthrough metadata information to help downstream projects build native libraries using llama.cpp build artifacts

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -199,6 +199,9 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("failed to write bindings to file");
+    let llama_cpp_dir = PathBuf::from("llama.cpp").canonicalize().unwrap();
+    println!("cargo:INCLUDE={}", llama_cpp_dir.to_str().unwrap());
+    println!("cargo:OUT_DIR={}", out_path.to_str().unwrap());
 }
 
 // courtesy of https://github.com/rustformers/llm


### PR DESCRIPTION
Added passthrough metadata information to help downstream projects build native libraries using llama.cpp build artifacts

Added INCLUDE pointing to llama.cpp source folder for header lookup 
Added OUT_DIR pointing to build output directory for object file lookup

This allows downstream projects access to llama.cpp header files, and llama.cpp object files to link with their own C-source and compile.
