### PR TITLE
fix: multi-byte utf8 decoding error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +916,7 @@ version = "0.1.46"
 dependencies = [
  "anyhow",
  "clap",
+ "encoding_rs",
  "hf-hub",
  "llama-cpp-2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bindgen = "0.69.4"
 cc = "1.0.90"
 anyhow = "1.0.81"
 clap = "4.5.3"
+encoding_rs = "0.8.33"
 
 [workspace.lints.rust]
 missing_docs = { level = "warn" }

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -10,6 +10,7 @@ llama-cpp-2 = { path = "../llama-cpp-2", version = "0.1.46" }
 hf-hub = { workspace = true }
 clap = { workspace = true , features = ["derive"] }
 anyhow = { workspace = true }
+encoding_rs = { workspace = true }
 
 [features]
 cublas = ["llama-cpp-2/cublas"]

--- a/simple/src/main.rs
+++ b/simple/src/main.rs
@@ -240,6 +240,9 @@ either reduce n_len or increase n_ctx"
 
     let t_main_start = ggml_time_us();
 
+    // The `Decoder`
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+
     while n_cur <= n_len {
         // sample the next token
         {
@@ -256,7 +259,11 @@ either reduce n_len or increase n_ctx"
                 break;
             }
 
-            print!("{}", model.token_to_str(new_token_id)?);
+            let output_bytes = model.token_to_bytes(new_token_id)?;
+            // use `Decoder.decode_to_string()` to avoid the intermediate buffer
+            let mut output_string = String::with_capacity(32);
+            let _decode_result = decoder.decode_to_string(&output_bytes, &mut output_string, false);
+            print!("{}", output_string);
             std::io::stdout().flush()?;
 
             batch.clear();


### PR DESCRIPTION
The `llama_token_to_piece()` function returns bytes that may not always represent a complete UTF-8 sequence. 

- https://github.com/ggerganov/llama.cpp/discussions/3114

When encountering multi-byte UTF-8 characters, there's a possibility that a character could be split and returned in two parts. 

https://github.com/utilityai/llama-cpp-rs/blob/48cc14a2fc6c63e958ea0b966907983e71822232/llama-cpp-2/src/model.rs#L238

This would result in an error when attempting to convert these bytes into a string using `String::from_utf8`. 

```
        #ggml_metal_free: deallocating
Error: FromUtf8Error incomplete utf-8 byte sequence from index 1

Caused by:
    incomplete utf-8 byte sequence from index 1
```

My solution is to introduce the `model.token_to_bytes` function that directly returns bytes, and then to apply `encoding_rs` for decoding throughout the entire loop.

