### PR TITLE
new feature `metal` to turn on/off metal framework on macos

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -15,7 +15,11 @@ tracing = { workspace = true }
 
 [features]
 cublas = ["llama-cpp-sys-2/cublas"]
+metal = ["llama-cpp-sys-2/metal"]
 sampler = []
+
+[target.'cfg(all(target_os = "macos", any(target_arch = "aarch64", target_arch = "arm64")))'.dependencies]  
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", features=["metal"], version = "0.1.48" }
 
 [lints]
 workspace = true

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -46,4 +46,5 @@ cc = { workspace = true, features = ["parallel"] }
 
 [features]
 cublas = []
+metal = []
 

--- a/simple/Cargo.toml
+++ b/simple/Cargo.toml
@@ -14,6 +14,7 @@ encoding_rs = { workspace = true }
 
 [features]
 cublas = ["llama-cpp-2/cublas"]
+metal =  ["llama-cpp-2/metal"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
1. Metal framework doesn't work on MacOS X86_64, a new feature 'metal' is added.
If the target is 'macos' and 'aarch64', the feature is on by default.

2. `llama.cpp` and `ollama` have the same issue, only  `Acelerate`(pure CPU) works on macos.

