### PR TITLE
Fix character range grammar parsing

### DIFF
--- a/llama-cpp-2/src/grammar.rs
+++ b/llama-cpp-2/src/grammar.rs
@@ -294,8 +294,8 @@ impl ParseState {
                         type_: gre_type,
                         value: c as _,
                     });
-                    if rest.starts_with("-]") {
-                        let (c, r) = Self::parse_char(rest)?;
+                    if rest.starts_with("-") && rest.get(1..).is_some_and(|r| !r.starts_with("]")) {
+                        let (c, r) = Self::parse_char(&rest[1..])?;
                         rest = r;
                         rule.push(llama_grammar_element {
                             type_: llama_cpp_sys_2::LLAMA_GRETYPE_CHAR_RNG_UPPER,

--- a/llama-cpp-2/src/grammar/tests.rs
+++ b/llama-cpp-2/src/grammar/tests.rs
@@ -55,3 +55,36 @@ fn check_parse_simple() {
         parse_state
     );
 }
+
+#[test]
+fn check_parse_char_range() {
+    let parse_state = ParseState::from_str(r#"root ::= [a-zA-Z]"#).unwrap();
+    assert_eq!(
+        ParseState {
+            symbol_ids: BTreeMap::from([("root".to_string(), 0),]),
+            rules: vec![vec![
+                llama_grammar_element {
+                    type_: llama_cpp_sys_2::LLAMA_GRETYPE_CHAR,
+                    value: 'a' as u32
+                },
+                llama_grammar_element {
+                    type_: llama_cpp_sys_2::LLAMA_GRETYPE_CHAR_RNG_UPPER,
+                    value: 'z' as u32
+                },
+                llama_grammar_element {
+                    type_: llama_cpp_sys_2::LLAMA_GRETYPE_CHAR_ALT,
+                    value: 'A' as u32
+                },
+                llama_grammar_element {
+                    type_: llama_cpp_sys_2::LLAMA_GRETYPE_CHAR_RNG_UPPER,
+                    value: 'Z' as u32
+                },
+                llama_grammar_element {
+                    type_: llama_cpp_sys_2::LLAMA_GRETYPE_END,
+                    value: 0
+                }
+            ]]
+        },
+        parse_state
+    );
+}


### PR DESCRIPTION
GBNF grammar for character ranges is not parsed correctly. For example, `[a-z]` is currently parsed as `("a" | "-" | "z")`.

This PR updates it to match upstream:
```cpp
if (pos[0] == '-' && pos[1] != ']') {
    if (!pos[1]) {
        throw std::runtime_error("unexpected end of input");
    }
    auto endchar_pair = parse_char(pos + 1);
         pos          = endchar_pair.second;
    out_elements.push_back({LLAMA_GRETYPE_CHAR_RNG_UPPER, endchar_pair.first});
}
```
https://github.com/ggerganov/llama.cpp/blob/72272b83a3878e91251218c981b4c6ec16c33912/common/grammar-parser.cpp#L241-L248