### PR TITLE
Simplify CPU features: just detect them in build.rs instead of exposing them as crate features

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -22,35 +22,6 @@ vulkan = ["llama-cpp-sys-2/vulkan"]
 native = ["llama-cpp-sys-2/native"]
 sampler = []
 
-[target.'cfg(target_feature = "avx")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "avx",
-] }
-[target.'cfg(target_feature = "avx2")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "avx2",
-] }
-[target.'cfg(target_feature = "avx512f")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "avx512",
-] }
-[target.'cfg(target_feature = "avx512vbmi")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "avx512_vmbi",
-] }
-[target.'cfg(target_feature = "avx512vnni")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "avx512_vnni",
-] }
-[target.'cfg(target_feature = "f16c")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "f16c",
-] }
-[target.'cfg(target_feature = "fma")'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
-    "fma",
-] }
-
 [target.'cfg(all(target_os = "macos", any(target_arch = "aarch64", target_arch = "arm64")))'.dependencies]
 llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.63", features = [
     "metal",

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -53,14 +53,7 @@ cc = { workspace = true, features = ["parallel"] }
 once_cell = "1.19.0"
 
 [features]
-avx = []
-avx2 = []
-avx512 = []
-avx512_vmbi = []
-avx512_vnni = []
 cuda = []
-f16c = []
-fma = []
 metal = []
 dynamic_link = []
 vulkan = []

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -259,59 +259,59 @@ fn push_feature_flags(cx: &mut Build, cxx: &mut Build) {
             cxx.flag("-march=native");
         }
 
-        if cfg!(feature = "fma") && cfg!(target_family = "unix") {
+        if cfg!(target_feature = "fma") && cfg!(target_family = "unix") {
             cx.flag("-mfma");
             cxx.flag("-mfma");
         }
 
-        if cfg!(feature = "f16c") && cfg!(target_family = "unix") {
+        if cfg!(target_feature = "f16c") && cfg!(target_family = "unix") {
             cx.flag("-mf16c");
             cxx.flag("-mf16c");
         }
 
         if cfg!(target_family = "unix") {
-            if cfg!(feature = "avx512") {
+            if cfg!(target_feature = "avx512f") {
                 cx.flag("-mavx512f").flag("-mavx512bw");
                 cxx.flag("-mavx512f").flag("-mavx512bw");
 
-                if cfg!(feature = "avx512_vmbi") {
+                if cfg!(target_feature = "avx512vbmi") {
                     cx.flag("-mavx512vbmi");
                     cxx.flag("-mavx512vbmi");
                 }
 
-                if cfg!(feature = "avx512_vnni") {
+                if cfg!(target_feature = "avx512vnni") {
                     cx.flag("-mavx512vnni");
                     cxx.flag("-mavx512vnni");
                 }
             }
 
-            if cfg!(feature = "avx2") {
+            if cfg!(target_feature = "avx2") {
                 cx.flag("-mavx2");
                 cxx.flag("-mavx2");
             }
 
-            if cfg!(feature = "avx") {
+            if cfg!(target_feature = "avx") {
                 cx.flag("-mavx");
                 cxx.flag("-mavx");
             }
         } else if cfg!(target_family = "windows") {
-            if cfg!(feature = "avx512") {
+            if cfg!(target_feature = "avx512f") {
                 cx.flag("/arch:AVX512");
                 cxx.flag("/arch:AVX512");
 
-                if cfg!(feature = "avx512_vmbi") {
+                if cfg!(target_feature = "avx512vbmi") {
                     cx.define("__AVX512VBMI__", None);
                     cxx.define("__AVX512VBMI__", None);
                 }
 
-                if cfg!(feature = "avx512_vnni") {
+                if cfg!(target_feature = "avx512vnni") {
                     cx.define("__AVX512VNNI__", None);
                     cxx.define("__AVX512VNNI__", None);
                 }
-            } else if cfg!(feature = "avx2") {
+            } else if cfg!(target_feature = "avx2") {
                 cx.flag("/arch:AVX2");
                 cxx.flag("/arch:AVX2");
-            } else if cfg!(feature = "avx") {
+            } else if cfg!(target_feature = "avx") {
                 cx.flag("/arch:AVX");
                 cxx.flag("/arch:AVX");
             }

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -271,8 +271,13 @@ fn push_feature_flags(cx: &mut Build, cxx: &mut Build) {
 
         if cfg!(target_family = "unix") {
             if cfg!(target_feature = "avx512f") {
-                cx.flag("-mavx512f").flag("-mavx512bw");
-                cxx.flag("-mavx512f").flag("-mavx512bw");
+                cx.flag("-mavx512f");
+                cxx.flag("-mavx512f");
+
+                if cfg!(target_feature = "avx512bw") {
+                    cx.flag("-mavx512bw");
+                    cxx.flag("-mavx512bw");
+                }
 
                 if cfg!(target_feature = "avx512vbmi") {
                     cx.flag("-mavx512vbmi");


### PR DESCRIPTION
Since #373, where I wrote
> Instead of exposing the features, ... I figured this arrangement made the most sense because, as far as I'm aware, it doesn't add additional build requirements (the way e.g. CUDA or Vulkan would) so there shouldn't be a chance of compilations that used to succeed before this PR beginning to fail with this change.
Users of llama-cpp-2 can ensure their available instruction set extensions are taken advantage of by either [specifying -C target-cpu=native in their RUSTFLAGS](https://doc.rust-lang.org/rustc/codegen-options/index.html#target-cpu) ...

I had an epiphany today that it would remove unnecessary code to just detect the CPU features in `build.rs` instead of exposing them as crate features. (and it would've prevented #393 lol oops) Since this part of the build script wasn't actually working yet, it was probably the original author's intention to check CPU features rather than crate features anyway.

(I don't have the means to test AVX512).