### PR TITLE
Enlarge the buffer in `LlamaModel::apply_chat_template`

### DIFF
--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -454,7 +454,7 @@ impl LlamaModel {
         let message_length = chat.iter().fold(0, |acc, c| {
             acc + c.role.to_bytes().len() + c.content.to_bytes().len()
         });
-        let mut buff: Vec<i8> = vec![0_i8; message_length * 2];
+        let mut buff: Vec<i8> = vec![0_i8; message_length * 4];
 
         // Build our llama_cpp_sys_2 chat messages
         let chat: Vec<llama_cpp_sys_2::llama_chat_message> = chat


### PR DESCRIPTION
Fixes #409

Per this comment I saw in the code,
https://github.com/utilityai/llama-cpp-rs/blob/64409ebaecb815e61a0c2747c51f858949c4d758/llama-cpp-2/src/model.rs#L485-L489

this PR just increases the buffer size from times 2 to times 4 (cause 3 wasn't enough to resolve the issue on my end).