### PR TITLE
BREAKING: Add a variant to `ChatTemplateError` and `LlamaModel::get_chat_template` for when the user specifies too small of a buffer

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -64,6 +64,9 @@ pub enum LLamaCppError {
 /// There was an error while getting the chat template from a model.
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ChatTemplateError {
+    /// the buffer was too small.
+    #[error("The buffer was too small. However, a buffer size of {0} would be just large enough.")]
+    BuffSizeError(usize),
     /// gguf has no chat template
     #[error("the model has no meta val - returned code {0}")]
     MissingTemplate(i32),


### PR DESCRIPTION
Fixes #411 but is a BREAKING CHANGE because this `enum` is not marked as `#[non_exhaustive]`, so any `match`es on it will now fail to compile if they don't have a fallback arm, or will now behave differently if they do.

Now, instead of panicking, `get_chat_template` will return a `ChatTemplateError::BuffSizeError(usize)` where the `usize` is the smallest size of a buffer that would be sufficiently large enough for `llama.cpp` to be able to print the chat template into.

A user could call `get_chat_template` again with the suggested buffer size to then be able to get it without error. (The alternative being just hoping to pass a sufficiently large buffer even if wasteful). 

Feel free to close this pull request if there's a better solution. I expect to write a future issue about creating a wrapper around `llama_model_meta_val_str` that allocates so the user doesn't have to specify a buffer size anyway.
