### PR TITLE
Remove unix-only libs from windows build

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -426,7 +426,7 @@ fn compile_cuda(cx: &mut Build, cxx: &mut Build, featless_cxx: Build) -> &'stati
     // }
 
     for lib in [
-        "cuda", "cublas", "culibos", "cudart", "cublasLt", "pthread", "dl", "rt",
+        "cuda", "cublas", "cudart", "cublasLt"
     ] {
         println!("cargo:rustc-link-lib={}", lib);
     }


### PR DESCRIPTION
Hey there, I noticed that windows CUDA builds were failing because of a missing `culibos.lib` and it seems like previously these libraries were excluded on windows in the build script and reverting to that seems to fix my build.