### PR TITLE
ci: fix version bumping GitHub Actions job

### DIFF
--- a/.github/workflows/update-toml-version.yaml
+++ b/.github/workflows/update-toml-version.yaml
@@ -33,17 +33,17 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$NEXT_VERSION\"/g" llama-cpp-2/Cargo.toml
           sed -i "s/^\(llama-cpp-sys-2 = { path = \"\.\.\/llama-cpp-sys-2\", version = \)\"$CURRENT_VERSION\"/\1\"$NEXT_VERSION\"/" llama-cpp-2/Cargo.toml       
           # Update the version in the simple Cargo.toml
-          sed -i "s/^version = \".*\"/version = \"$NEXT_VERSION\"/g" simple/Cargo.toml
-          sed -i "s/^\(llama-cpp-2 = { path = \"\.\.\/llama-cpp-2\", version = \)\"$CURRENT_VERSION\"/\1\"$NEXT_VERSION\"/" simple/Cargo.toml       
+          sed -i "s/^version = \".*\"/version = \"$NEXT_VERSION\"/g" examples/simple/Cargo.toml
+          sed -i "s/^\(llama-cpp-2 = { path = \"\.\.\/llama-cpp-2\", version = \)\"$CURRENT_VERSION\"/\1\"$NEXT_VERSION\"/" examples/simple/Cargo.toml       
           # Update the version in the root embeddings Cargo.toml
-          sed -i "s/^version = \".*\"/version = \"$NEXT_VERSION\"/g" embeddings/Cargo.toml
-          sed -i "s/^\(llama-cpp-2 = { path = \"\.\.\/llama-cpp-2\", version = \)\"$CURRENT_VERSION\"/\1\"$NEXT_VERSION\"/" embeddings/Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"$NEXT_VERSION\"/g" examples/embeddings/Cargo.toml
+          sed -i "s/^\(llama-cpp-2 = { path = \"\.\.\/llama-cpp-2\", version = \)\"$CURRENT_VERSION\"/\1\"$NEXT_VERSION\"/" examples/embeddings/Cargo.toml
           # Update Cargo.lock by running cargo check
           cargo check
           # Commit the changes
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
-          git add llama-cpp-sys-2/Cargo.toml llama-cpp-2/Cargo.toml simple/Cargo.toml embeddings/Cargo.toml Cargo.lock
+          git add llama-cpp-sys-2/Cargo.toml llama-cpp-2/Cargo.toml examples/simple/Cargo.toml examples/embeddings/Cargo.toml Cargo.lock
           git commit -m "Bump version to $NEXT_VERSION [skip ci]"
           # Create a  branch for the changes
           git checkout -b version-bump-$NEXT_VERSION


### PR DESCRIPTION
examples were placed in the `examples` directory in https://github.com/utilityai/llama-cpp-rs/pull/482 but this change was missed, so there's no longer automatic version bumping that might be contributing to the crates.io releases being behind

P.S. I've been enjoying how [Release-plz](https://release-plz.ieni.dev/) works if you'd find it beneficial to replace the `publish-upon-release` and `update-toml-version` workflows with it. (I prefer [the GitHub app approach](https://release-plz.ieni.dev/docs/github/token#use-a-github-app))