### PR TITLE
fix: make `llama-cpp-sys-2` publishable again

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -11,46 +11,46 @@ include = [
     "wrapper.h",
     "build.rs",
     "/src",
-    "/llama.cpp/ggml/src/ggml.c",
-    "/llama.cpp/ggml/include/ggml.h",
-    "/llama.cpp/ggml/src/ggml-alloc.c",
-    "/llama.cpp/ggml/include/ggml-alloc.h",
-    "/llama.cpp/ggml/src/ggml-backend.c",
-    "/llama.cpp/ggml/include/ggml-backend.h",
-    "/llama.cpp/ggml/src/ggml-backend-impl.h",
+
+    "/llama.cpp/common/*.h",
+    "/llama.cpp/common/*.hpp",
+    "/llama.cpp/common/*.cpp",
+    "/llama.cpp/ggml/include/*.h",
+    "/llama.cpp/ggml/src/*.h",
+    "/llama.cpp/ggml/src/*.c",
+    "/llama.cpp/ggml/src/*.cpp",
+    "/llama.cpp/src/*.h",
+    "/llama.cpp/src/*.cpp",
+
+    "/llama.cpp/convert_hf_to_gguf.py", # Yes, it's required
+
+    "/llama.cpp/common/build-info.cpp.in",
+
     "/llama.cpp/ggml/src/ggml-cuda.cu",
-    "/llama.cpp/ggml/include/ggml-cuda.h",
-    "/llama.cpp/ggml/src/ggml-impl.h",
     "/llama.cpp/ggml/src/ggml-metal.m",
     "/llama.cpp/ggml/src/ggml-metal.metal",
-    "/llama.cpp/ggml/include/ggml-metal.h",
-    "/llama.cpp/ggml/src/ggml-mpi.c",
-    "/llama.cpp/ggml/src/ggml-mpi.h",
-    "/llama.cpp/ggml/src/ggml-opencl.cpp",
-    "/llama.cpp/ggml/src/ggml-opencl.h",
-    "/llama.cpp/ggml/src/ggml-quants.c",
-    "/llama.cpp/ggml/src/ggml-quants.h",
-    "/llama.cpp/src/llama.cpp",
-    "/llama.cpp/src/llama-impl.h",
-    "/llama.cpp/src/llama-vocab.h",
-    "/llama.cpp/src/llama-vocab.cpp",
-    "/llama.cpp/src/llama-grammar.h",
-    "/llama.cpp/src/llama-grammar.cpp",
-    "/llama.cpp/src/llama-sampling.h",
-    "/llama.cpp/src/llama-sampling.cpp",
+
     "/llama.cpp/include/llama.h",
-    "/llama.cpp/src/unicode.h",
-    "/llama.cpp/src/unicode.cpp",
-    "/llama.cpp/src/unicode-data.h",
-    "/llama.cpp/src/unicode-data.h",
-    "/llama.cpp/src/unicode-data.cpp",
-    "/llama.cpp/ggml/src/ggml-common.h",
-    "/llama.cpp/ggml/src/ggml-cuda",
-    "/llama.cpp/ggml/sgemm.h",
-    "/llama.cpp/ggml/src/ggml-cuda/*",
-    "/llama.cpp/ggml/src/ggml-cuda/template_instances/*",
-    "/llama.cpp/ggml/src/ggml-aarch64.h",
-    "/llama.cpp/ggml/src/ggml-aarch64.c",
+
+    "/llama.cpp/ggml/src/ggml-cuda/**/*",
+
+    "/llama.cpp/ggml/src/vulkan-shaders/**/*",
+
+    "/llama.cpp/ggml/src/llamafile/sgemm.h",
+    "/llama.cpp/ggml/src/llamafile/sgemm.cpp",
+
+    "/llama.cpp/pocs",
+
+    "/llama.cpp/CMakeLists.txt",
+    "/llama.cpp/common/CMakeLists.txt",
+    "/llama.cpp/ggml/CMakeLists.txt",
+    "/llama.cpp/ggml/src/CMakeLists.txt",
+    "/llama.cpp/ggml/src/vulkan-shaders/CMakeLists.txt",
+    "/llama.cpp/src/CMakeLists.txt",
+
+    "/llama.cpp/cmake",
+    "/llama.cpp/ggml/cmake",
+    "/llama.cpp/common/cmake",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -212,11 +212,17 @@ fn main() {
 
     let mut config = Config::new(&llama_dst);
 
-    config
-        .define(
-            "BUILD_SHARED_LIBS",
-            if build_shared_libs { "ON" } else { "OFF" },
-        );
+    // Would require extra source files to pointlessly
+    // be included in what's uploaded to and downloaded from
+    // crates.io, so deactivating these instead
+    config.define("LLAMA_BUILD_TESTS", "OFF");
+    config.define("LLAMA_BUILD_EXAMPLES", "OFF");
+    config.define("LLAMA_BUILD_SERVER", "OFF");
+
+    config.define(
+        "BUILD_SHARED_LIBS",
+        if build_shared_libs { "ON" } else { "OFF" },
+    );
 
     if cfg!(target_os = "macos") {
         config.define("GGML_BLAS", "OFF");


### PR DESCRIPTION
~~more inclusions are likely needed for CUDA and Vulkan,~~ and the others

both Vulkan and CUDA (I don't have the CUDA Toolkit installed so I don't even know how this is possible) compile when [downloading it back from crates.io](https://crates.io/crates/babichjacob-llama-cpp-sys-2) on my end, but I'm not sure I did that right... 

closes #518