### PR TITLE
Bump llama.cpp to b4206

### DIFF
--- a/llama-cpp-2/src/llama_batch.rs
+++ b/llama-cpp-2/src/llama_batch.rs
@@ -157,17 +157,13 @@ impl LlamaBatch {
     ///
     /// NOTE: this is a helper function to facilitate transition to the new batch API
     ///
-    pub fn get_one(
-        tokens: &[LlamaToken],
-        pos_0: llama_pos,
-        seq_id: llama_seq_id,
-    ) -> Result<Self, BatchAddError> {
+    pub fn get_one(tokens: &[LlamaToken]) -> Result<Self, BatchAddError> {
         if tokens.is_empty() {
             return Err(BatchAddError::EmptyBuffer);
         }
         let batch = unsafe {
             let ptr = tokens.as_ptr() as *mut i32;
-            llama_cpp_sys_2::llama_batch_get_one(ptr, tokens.len() as i32, pos_0, seq_id)
+            llama_cpp_sys_2::llama_batch_get_one(ptr, tokens.len() as i32)
         };
         let batch = Self {
             allocated: 0,


### PR DESCRIPTION
Does what it says on the tin. :innocent: 

This is a breaking change, since `LlamaBatch::get_one` now accepts two fewer arguments. But maybe llama-cpp-rs doesn't do semantic versioning anyway?