### PR TITLE
Add greedy decoding to example 'simple'

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -247,7 +247,9 @@ either reduce n_len or increase n_ctx"
     let mut decoder = encoding_rs::UTF_8.new_decoder();
 
     let sampler_params = LlamaSamplerChainParams::default();
-    let mut sampler = LlamaSampler::new(sampler_params)?.add_dist(seed.unwrap_or(1234));
+    let mut sampler = LlamaSampler::new(sampler_params)?
+        .add_dist(seed.unwrap_or(1234))
+        .add_greedy();
 
     while n_cur <= n_len {
         // sample the next token


### PR DESCRIPTION
Run the example following the README: `cargo run --release --bin simple -- --prompt "The way to kill a linux process is" hf-model TheBloke/Llama-2-7B-GGUF llama-2-7b.Q4_K_M.gguf`

Before modification:

```
 The way to kill a linux process is给给给给给给给给给给给给给给给给给给给给给给给给
```

After modification:

```
 The way to kill a linux process is to send it a SIGKILL signal.
The way to kill a windows process is to send it a S
```