### PR TITLE
update the `include`d files in `llama-cpp-sys-2` so that the crate can be published again

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -31,10 +31,11 @@ include = [
     "/llama.cpp/ggml/src/ggml-metal.metal",
 
     "/llama.cpp/include/llama.h",
+    "/llama.cpp/include/llama-cpp.h",
 
+    "/llama.cpp/ggml/src/ggml-cpu/**/*",
     "/llama.cpp/ggml/src/ggml-cuda/**/*",
-
-    "/llama.cpp/ggml/src/vulkan-shaders/**/*",
+    "/llama.cpp/ggml/src/ggml-vulkan/**/*",
 
     "/llama.cpp/ggml/src/llamafile/sgemm.h",
     "/llama.cpp/ggml/src/llamafile/sgemm.cpp",
@@ -45,7 +46,6 @@ include = [
     "/llama.cpp/common/CMakeLists.txt",
     "/llama.cpp/ggml/CMakeLists.txt",
     "/llama.cpp/ggml/src/CMakeLists.txt",
-    "/llama.cpp/ggml/src/vulkan-shaders/CMakeLists.txt",
     "/llama.cpp/src/CMakeLists.txt",
 
     "/llama.cpp/cmake",


### PR DESCRIPTION
closes #591 