### PR TITLE
Build for aarch64-linux-android

### DIFF
--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -20,6 +20,15 @@ impl Debug for LlamaSampler {
     }
 }
 
+// this is needed for the dry sampler to typecheck on android
+// ...because what is normally an i8, is an u8 
+#[cfg(target_os = "android")]
+type CChar = u8;
+
+#[cfg(not(target_os = "android"))]
+type CChar = i8;
+
+
 impl LlamaSampler {
     /// Sample and accept a token from the idx-th output of the last evaluation
     #[must_use]
@@ -254,7 +263,7 @@ impl LlamaSampler {
             .into_iter()
             .map(|s| CString::new(s.as_ref()).unwrap())
             .collect();
-        let mut seq_breaker_pointers: Vec<*const i8> =
+        let mut seq_breaker_pointers: Vec<*const CChar> =
             seq_breakers.iter().map(|s| s.as_ptr()).collect();
 
         let sampler = unsafe {

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -235,7 +235,6 @@ fn main() {
         // https://github.com/ggerganov/llama.cpp/blob/master/docs/android.md
         let android_ndk = env::var("ANDROID_NDK")
             .expect("Please install Android NDK and ensure that ANDROID_NDK env variable is set");
-        config.define("LLAMA_CURL", "OFF");
         config.define(
             "CMAKE_TOOLCHAIN_FILE",
             format!("{android_ndk}/build/cmake/android.toolchain.cmake"),

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -230,6 +230,25 @@ fn main() {
         config.static_crt(static_crt);
     }
 
+    if target.contains("android") && target.contains("aarch64") {
+        // build flags for android taken from this doc
+        // https://github.com/ggerganov/llama.cpp/blob/master/docs/android.md
+        let android_ndk = env::var("ANDROID_NDK")
+            .expect("Please install Android NDK and ensure that ANDROID_NDK env variable is set");
+        config.define("LLAMA_CURL", "OFF");
+        config.define(
+            "CMAKE_TOOLCHAIN_FILE",
+            format!("{android_ndk}/build/cmake/android.toolchain.cmake"),
+        );
+        config.define("ANDROID_ABI", "arm64-v8a");
+        config.define("ANDROID_PLATFORM", "android-28");
+        config.define("CMAKE_SYSTEM_PROCESSOR", "arm64");
+        config.define("CMAKE_C_FLAGS", "-march=armv8.7a");
+        config.define("CMAKE_CXX_FLAGS", "-march=armv8.7a");
+        config.define("GGML_OPENMP", "OFF");
+        config.define("GGML_LLAMAFILE", "OFF");
+    }
+
     if cfg!(feature = "vulkan") {
         config.define("GGML_VULKAN", "ON");
         if cfg!(windows) {


### PR DESCRIPTION
...does what it says on the tin.

We're building a Godot plugin, and people are requesting android support.

It seems to work for us:
https://github.com/nobodywho-ooo/nobodywho/pull/67

There are two changes:
  1. I add the cmake flags suggested in the llama.cpp docs [here](https://github.com/ggerganov/llama.cpp/blob/master/docs/android.md), if the target string contains "android" and "aarch64"
  2. The DRY sampler contains an `i8` type that is an `u8` in the android NDK. I just set this type to be a `u8` whe compiling for android.

I'm not really an android dev, so not an expert on any of this. But it seems to work.