### PR TITLE
Fix arguments of sampling methods; Make chat templates and detokenization more reliable

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -280,9 +280,6 @@ pub enum NewLlamaChatMessageError {
 /// Failed to apply model chat template.
 #[derive(Debug, thiserror::Error)]
 pub enum ApplyChatTemplateError {
-    /// the buffer was too small.
-    #[error("The buffer was too small. Please contact a maintainer and we will update it.")]
-    BuffSizeError,
     /// the string contained a null byte and thus could not be converted to a c string.
     #[error("{0}")]
     NulError(#[from] NulError),

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -1,5 +1,4 @@
 //! A safe wrapper around `llama_model`.
-use std::ffi::CStr;
 use std::ffi::CString;
 use std::num::NonZeroU16;
 use std::os::raw::c_int;
@@ -124,7 +123,7 @@ impl LlamaModel {
         unsafe { llama_cpp_sys_2::llama_token_is_eog(self.model.as_ptr(), token.0) }
     }
 
-    /// Get the decoder start token token.
+    /// Get the decoder start token.
     #[must_use]
     pub fn decode_start_token(&self) -> LlamaToken {
         let token =
@@ -142,7 +141,8 @@ impl LlamaModel {
         token: LlamaToken,
         special: Special,
     ) -> Result<String, TokenToStringError> {
-        self.token_to_str_with_size(token, 32, special)
+        let bytes = self.token_to_bytes(token, special)?;
+        Ok(String::from_utf8(bytes)?)
     }
 
     /// Convert single token to bytes.
@@ -155,7 +155,12 @@ impl LlamaModel {
         token: LlamaToken,
         special: Special,
     ) -> Result<Vec<u8>, TokenToStringError> {
-        self.token_to_bytes_with_size(token, 32, special, None)
+        match self.token_to_bytes_with_size(token, 8, special, None) {
+            Err(TokenToStringError::InsufficientBufferSpace(i)) => {
+                self.token_to_bytes_with_size(token, -i as usize, special, None)
+            }
+            x => x,
+        }
     }
 
     /// Convert a vector of tokens to a single string.
@@ -168,15 +173,15 @@ impl LlamaModel {
         tokens: &[LlamaToken],
         special: Special,
     ) -> Result<String, TokenToStringError> {
-        let mut builder = String::with_capacity(tokens.len() * 4);
-        for str in tokens
+        let mut builder: Vec<u8> = Vec::with_capacity(tokens.len() * 4);
+        for piece in tokens
             .iter()
             .copied()
-            .map(|t| self.token_to_str(t, special))
+            .map(|t| self.token_to_bytes(t, special))
         {
-            builder += &str?;
+            builder.extend_from_slice(&piece?);
         }
-        Ok(builder)
+        Ok(String::from_utf8(builder)?)
     }
 
     /// Convert a string to a Vector of tokens.
@@ -212,7 +217,7 @@ impl LlamaModel {
         };
 
         let tokens_estimation = std::cmp::max(8, (str.len() / 2) + usize::from(add_bos));
-        let mut buffer = Vec::with_capacity(tokens_estimation);
+        let mut buffer: Vec<LlamaToken> = Vec::with_capacity(tokens_estimation);
 
         let c_string = CString::new(str)?;
         let buffer_capacity =
@@ -223,7 +228,7 @@ impl LlamaModel {
                 self.model.as_ptr(),
                 c_string.as_ptr(),
                 c_int::try_from(c_string.as_bytes().len())?,
-                buffer.as_mut_ptr(),
+                buffer.as_mut_ptr() as *mut llama_cpp_sys_2::llama_token,
                 buffer_capacity,
                 add_bos,
                 true,
@@ -239,7 +244,7 @@ impl LlamaModel {
                     self.model.as_ptr(),
                     c_string.as_ptr(),
                     c_int::try_from(c_string.as_bytes().len())?,
-                    buffer.as_mut_ptr(),
+                    buffer.as_mut_ptr() as *mut llama_cpp_sys_2::llama_token,
                     -size,
                     add_bos,
                     true,
@@ -253,7 +258,7 @@ impl LlamaModel {
 
         // Safety: `size` < `capacity` and llama-cpp has initialized elements up to `size`
         unsafe { buffer.set_len(size) }
-        Ok(buffer.into_iter().map(LlamaToken).collect())
+        Ok(buffer)
     }
 
     /// Get the type of a token.
@@ -269,8 +274,8 @@ impl LlamaModel {
 
     /// Convert a token to a string with a specified buffer size.
     ///
-    /// Generally you should use [`LlamaModel::token_to_str`] instead as 8 bytes is enough for most words and
-    /// the extra bytes do not really matter.
+    /// Generally you should use [`LlamaModel::token_to_str`] as it is able to decode tokens with
+    /// any length.
     ///
     /// # Errors
     ///
@@ -294,8 +299,8 @@ impl LlamaModel {
 
     /// Convert a token to bytes with a specified buffer size.
     ///
-    /// Generally you should use [`LlamaModel::token_to_bytes`] instead as 8 bytes is enough for most words and
-    /// the extra bytes do not really matter.
+    /// Generally you should use [`LlamaModel::token_to_bytes`] as it is able to handle tokens of
+    /// any length.
     ///
     /// # Errors
     ///
@@ -523,7 +528,7 @@ impl LlamaModel {
         let message_length = chat.iter().fold(0, |acc, c| {
             acc + c.role.to_bytes().len() + c.content.to_bytes().len()
         });
-        let mut buff = vec![0; message_length * 4];
+        let mut buff: Vec<u8> = vec![0; message_length * 2];
 
         // Build our llama_cpp_sys_2 chat messages
         let chat: Vec<llama_cpp_sys_2::llama_chat_message> = chat
@@ -541,28 +546,36 @@ impl LlamaModel {
             None => std::ptr::null(),
         };
 
-        let formatted_chat = unsafe {
-            let res = llama_cpp_sys_2::llama_chat_apply_template(
+        let mut res = unsafe {
+            llama_cpp_sys_2::llama_chat_apply_template(
                 self.model.as_ptr(),
                 tmpl_ptr,
                 chat.as_ptr(),
                 chat.len(),
                 add_ass,
-                buff.as_mut_ptr(),
+                buff.as_mut_ptr().cast::<i8>(),
                 buff.len() as i32,
-            );
-            // A buffer twice the size should be sufficient for all models, if this is not the case for a new model, we can increase it
-            // The error message informs the user to contact a maintainer
-            if res > buff.len() as i32 {
-                return Err(ApplyChatTemplateError::BuffSizeError);
-            }
-            Ok::<String, ApplyChatTemplateError>(
-                CStr::from_ptr(buff.as_mut_ptr())
-                    .to_string_lossy()
-                    .to_string(),
             )
-        }?;
-        Ok(formatted_chat)
+        };
+
+        if res > buff.len() as i32 {
+            buff.resize(res as usize, 0);
+
+            res = unsafe {
+                llama_cpp_sys_2::llama_chat_apply_template(
+                    self.model.as_ptr(),
+                    tmpl_ptr,
+                    chat.as_ptr(),
+                    chat.len(),
+                    add_ass,
+                    buff.as_mut_ptr().cast::<i8>(),
+                    buff.len() as i32,
+                )
+            };
+            assert!(res > buff.len() as i32);
+        }
+        buff.truncate(res as usize);
+        Ok(String::from_utf8(buff)?)
     }
 }
 

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -546,7 +546,7 @@ impl LlamaModel {
             None => std::ptr::null(),
         };
 
-        let mut res = unsafe {
+        let res = unsafe {
             llama_cpp_sys_2::llama_chat_apply_template(
                 self.model.as_ptr(),
                 tmpl_ptr,
@@ -561,7 +561,7 @@ impl LlamaModel {
         if res > buff.len() as i32 {
             buff.resize(res as usize, 0);
 
-            res = unsafe {
+            let res = unsafe {
                 llama_cpp_sys_2::llama_chat_apply_template(
                     self.model.as_ptr(),
                     tmpl_ptr,

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -572,7 +572,7 @@ impl LlamaModel {
                     buff.len() as i32,
                 )
             };
-            assert!(res > buff.len() as i32);
+            assert_eq!(res, buff.len() as i32);
         }
         buff.truncate(res as usize);
         Ok(String::from_utf8(buff)?)

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -23,7 +23,7 @@ impl Debug for LlamaSampler {
 impl LlamaSampler {
     /// Sample and accept a token from the idx-th output of the last evaluation
     #[must_use]
-    pub fn sample(&self, ctx: &LlamaContext, idx: i32) -> LlamaToken {
+    pub fn sample(&mut self, ctx: &LlamaContext, idx: i32) -> LlamaToken {
         let token = unsafe {
             llama_cpp_sys_2::llama_sampler_sample(self.sampler, ctx.context.as_ptr(), idx)
         };
@@ -32,7 +32,7 @@ impl LlamaSampler {
     }
 
     /// Applies this sampler to a [`LlamaTokenDataArray`].
-    pub fn apply(&mut self, data_array: &mut LlamaTokenDataArray) {
+    pub fn apply(&self, data_array: &mut LlamaTokenDataArray) {
         data_array.apply_sampler(self);
     }
 
@@ -53,7 +53,10 @@ impl LlamaSampler {
     /// Accepts several tokens from the sampler or context, possibly updating the internal state of
     /// certain samplers (e.g. grammar, repetition, etc.)
     #[must_use]
-    pub fn with_tokens(mut self, tokens: impl IntoIterator<Item = impl Borrow<LlamaToken>>) -> Self {
+    pub fn with_tokens(
+        mut self,
+        tokens: impl IntoIterator<Item = impl Borrow<LlamaToken>>,
+    ) -> Self {
         self.accept_many(tokens);
         self
     }
@@ -215,7 +218,7 @@ impl LlamaSampler {
         Self { sampler }
     }
 
-    /// Grammar sampler 
+    /// Grammar sampler
     ///
     /// # Panics
     /// If either of ``grammar_str`` or ``grammar_root`` contain null bytes.
@@ -386,10 +389,10 @@ impl LlamaSampler {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_dist(seed) };
         Self { sampler }
     }
- 
+
     /// Selects the most likely token
     ///
-    /// # Example: 
+    /// # Example:
     /// ```rust
     /// use llama_cpp_2::token::{
     ///    LlamaToken,

--- a/llama-cpp-2/src/token/data_array.rs
+++ b/llama-cpp-2/src/token/data_array.rs
@@ -1,10 +1,7 @@
 //! an rusty equivalent of `llama_token_data_array`.
 use std::ptr;
 
-use crate::{
-    sampling::LlamaSampler,
-    token::data::LlamaTokenData,
-};
+use crate::{sampling::LlamaSampler, token::data::LlamaTokenData};
 
 use super::LlamaToken;
 
@@ -124,7 +121,7 @@ impl LlamaTokenDataArray {
     }
 
     /// Modifies the data array by applying a sampler to it
-    pub fn apply_sampler(&mut self, sampler: &mut LlamaSampler) {
+    pub fn apply_sampler(&mut self, sampler: &LlamaSampler) {
         unsafe {
             self.modify_as_c_llama_token_data_array(|c_llama_token_data_array| {
                 llama_cpp_sys_2::llama_sampler_apply(sampler.sampler, c_llama_token_data_array);


### PR DESCRIPTION
Uses the correct mutability modifiers for sampling methods. Also makes it so that we use the return values of llama_token_to_piece and llama_apply_chat_template to resize the buffer and try again. The current implementations were causing issues with Llama 3.1, as it uses a very long chat template and has tokens that are more than 32 bytes long.

These changes have been tested against <https://github.com/nkoppel/llama-cpp-steganography>.