### PR TITLE
Redirect llama.cpp logs into tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "cc",
  "cmake",
  "glob",
+ "walkdir",
 ]
 
 [[package]]
@@ -988,6 +989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1276,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1310,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,7 @@ dependencies = [
  "llama-cpp-sys-2",
  "thiserror",
  "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -728,6 +729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +799,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "percent-encoding"
@@ -1061,6 +1078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1101,7 @@ dependencies = [
  "encoding_rs",
  "hf-hub",
  "llama-cpp-2",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1162,6 +1189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1237,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1270,6 +1346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1395,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,6 +1418,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 # core library deps
 thiserror = "1"
 tracing = "0.1"
+tracing-core = "0.1"
 
 # examples and benchmarks
 hf-hub = { version = "0.3.2" }
@@ -21,6 +22,7 @@ cc = "1.2.11"
 anyhow = "1.0.95"
 clap = "4.5.27"
 encoding_rs = "0.8.35"
+tracing-subscriber = { version = "0.3", features = ["json"] }
 
 [workspace.lints.rust]
 missing_docs = { level = "warn" }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -11,6 +11,7 @@ hf-hub = { workspace = true }
 clap = { workspace = true , features = ["derive"] }
 anyhow = { workspace = true }
 encoding_rs = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 cuda = ["llama-cpp-2/cuda"]

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -13,6 +13,7 @@ enumflags2 = "0.7.11"
 llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.69" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+tracing-core = { workspace = true }
 
 [dev-dependencies]
 encoding_rs = { workspace = true }

--- a/llama-cpp-2/src/log.rs
+++ b/llama-cpp-2/src/log.rs
@@ -1,0 +1,256 @@
+use super::LogOptions;
+use std::sync::OnceLock;
+use tracing_core::{callsite, field, identify_callsite, Interest, Kind, Metadata};
+
+static FIELD_NAMES: &[&str] = &["message", "module"];
+
+struct OverridableFields {
+    message: tracing::field::Field,
+    target: tracing::field::Field,
+}
+
+macro_rules! log_cs {
+    ($level:expr, $cs:ident, $meta:ident, $fields:ident, $ty:ident) => {
+        struct $ty;
+        static $cs: $ty = $ty;
+        static $meta: Metadata<'static> = Metadata::new(
+            "log event",
+            "llama-cpp-2",
+            $level,
+            ::core::option::Option::None,
+            ::core::option::Option::None,
+            ::core::option::Option::None,
+            field::FieldSet::new(FIELD_NAMES, identify_callsite!(&$cs)),
+            Kind::EVENT,
+        );
+        static $fields: std::sync::LazyLock<OverridableFields> = std::sync::LazyLock::new(|| {
+            let fields = $meta.fields();
+            OverridableFields {
+                message: fields.field("message").unwrap(),
+                target: fields.field("module").unwrap(),
+            }
+        });
+
+        impl callsite::Callsite for $ty {
+            fn set_interest(&self, _: Interest) {}
+            fn metadata(&self) -> &'static Metadata<'static> {
+                &$meta
+            }
+        }
+    };
+}
+log_cs!(
+    tracing_core::Level::DEBUG,
+    DEBUG_CS,
+    DEBUG_META,
+    DEBUG_FIELDS,
+    DebugCallsite
+);
+log_cs!(
+    tracing_core::Level::INFO,
+    INFO_CS,
+    INFO_META,
+    INFO_FIELDS,
+    InfoCallsite
+);
+log_cs!(
+    tracing_core::Level::WARN,
+    WARN_CS,
+    WARN_META,
+    WARN_FIELDS,
+    WarnCallsite
+);
+log_cs!(
+    tracing_core::Level::ERROR,
+    ERROR_CS,
+    ERROR_META,
+    ERROR_FIELDS,
+    ErrorCallsite
+);
+
+#[derive(Clone, Copy)]
+pub(super) enum Module {
+    GGML,
+    LlamaCpp,
+}
+
+impl Module {
+    const fn name(&self) -> &'static str {
+        match self {
+            Module::GGML => "ggml",
+            Module::LlamaCpp => "llama.cpp",
+        }
+    }
+}
+
+fn meta_for_level(
+    level: llama_cpp_sys_2::ggml_log_level,
+) -> (&'static Metadata<'static>, &'static OverridableFields) {
+    match level {
+        llama_cpp_sys_2::GGML_LOG_LEVEL_DEBUG => (&DEBUG_META, &DEBUG_FIELDS),
+        llama_cpp_sys_2::GGML_LOG_LEVEL_INFO => (&INFO_META, &INFO_FIELDS),
+        llama_cpp_sys_2::GGML_LOG_LEVEL_WARN => (&WARN_META, &WARN_FIELDS),
+        llama_cpp_sys_2::GGML_LOG_LEVEL_ERROR => (&ERROR_META, &ERROR_FIELDS),
+        _ => {
+            unreachable!("Illegal log level to be called here")
+        }
+    }
+}
+
+pub(super) struct State {
+    pub(super) options: LogOptions,
+    module: Module,
+    buffered: std::sync::Mutex<Option<(llama_cpp_sys_2::ggml_log_level, String)>>,
+    previous_level: std::sync::atomic::AtomicI32,
+    is_buffering: std::sync::atomic::AtomicBool,
+}
+
+impl State {
+    pub(super) fn new(module: Module, options: LogOptions) -> Self {
+        Self {
+            options,
+            module,
+            buffered: Default::default(),
+            previous_level: Default::default(),
+            is_buffering: Default::default(),
+        }
+    }
+
+    fn generate_log(target: Module, level: llama_cpp_sys_2::ggml_log_level, text: &str) {
+        // Annoying but tracing requires that the provided target name is a string literal and
+        // even &'static str isn't enough so we have to duplicate the generation AND we can't even
+        // extract the interrior module within llama.cpp/ggml to be able to propagate it forward.
+        // This happens because the target is part of a static variable injected by the macro that's
+        // initialized with said target.
+
+        let (module, text) = text
+            .char_indices()
+            .take_while(|(_, c)| c.is_ascii_lowercase() || *c == '_')
+            .last()
+            .and_then(|(pos, _)| {
+                let next_two = text.get(pos + 1..pos + 3);
+                if next_two == Some(": ") {
+                    let (sub_module, text) = text.split_at(pos + 1);
+                    let text = text.split_at(2).1;
+                    Some((Some(format!("{}::{sub_module}", target.name())), text))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or((None, text));
+
+        let (meta, fields) = meta_for_level(level);
+
+        tracing::dispatcher::get_default(|dispatcher| {
+            dispatcher.event(&tracing::Event::new(
+                meta,
+                &meta.fields().value_set(&[
+                    (&fields.message, Some(&text as &dyn tracing::field::Value)),
+                    (
+                        &fields.target,
+                        module.as_ref().map(|s| s as &dyn tracing::field::Value),
+                    ),
+                ]),
+            ));
+        });
+    }
+
+    /// Append more text to the previously buffered log. The text may or may not end with a newline.
+    pub(super) fn cont_buffered_log(&self, text: &str) {
+        let mut lock = self.buffered.lock().unwrap();
+
+        if let Some((previous_log_level, mut buffer)) = lock.take() {
+            buffer.push_str(text);
+            if buffer.ends_with('\n') {
+                self.is_buffering
+                    .store(false, std::sync::atomic::Ordering::Release);
+                Self::generate_log(self.module, previous_log_level, buffer.as_str());
+            } else {
+                *lock = Some((previous_log_level, buffer));
+            }
+        } else {
+            let level = self
+                .previous_level
+                .load(std::sync::atomic::Ordering::Acquire) as llama_cpp_sys_2::ggml_log_level;
+            tracing::warn!(
+                inferred_level = level,
+                text = text,
+                origin = "crate",
+                "llma.cpp sent out a CONT log without any previously buffered message"
+            );
+            *lock = Some((level, text.to_string()));
+        }
+    }
+
+    /// Start buffering a message. Not the CONT log level and text is missing a newline.
+    pub(super) fn buffer_non_cont(&self, level: llama_cpp_sys_2::ggml_log_level, text: &str) {
+        debug_assert!(!text.ends_with('\n'));
+        debug_assert_ne!(level, llama_cpp_sys_2::GGML_LOG_LEVEL_CONT);
+
+        if let Some((previous_log_level, buffer)) = self
+            .buffered
+            .lock()
+            .unwrap()
+            .replace((level, text.to_string()))
+        {
+            tracing::warn!(
+                level = previous_log_level,
+                text = &buffer,
+                origin = "crate",
+                "Message buffered unnnecessarily due to missing newline and not followed by a CONT"
+            );
+            Self::generate_log(self.module, previous_log_level, buffer.as_str())
+        }
+
+        self.is_buffering
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.previous_level
+            .store(level as i32, std::sync::atomic::Ordering::Release);
+    }
+
+    // Emit a normal unbuffered log message (not the CONT log level and the text ends with a newline).
+    pub(super) fn emit_non_cont_line(&self, level: llama_cpp_sys_2::ggml_log_level, text: &str) {
+        debug_assert!(text.ends_with('\n'));
+        debug_assert_ne!(level, llama_cpp_sys_2::GGML_LOG_LEVEL_CONT);
+
+        if self
+            .is_buffering
+            .swap(false, std::sync::atomic::Ordering::Acquire)
+        {
+            if let Some((buf_level, buf_text)) = self.buffered.lock().unwrap().take() {
+                // This warning indicates a bug within llama.cpp
+                tracing::warn!(level = buf_level, text = buf_text, origin = "crate", "llama.cpp message buffered spuriously due to missing \\n and being followed by a non-CONT message!");
+                Self::generate_log(self.module, buf_level, buf_text.as_str());
+            }
+        }
+
+        self.previous_level
+            .store(level as i32, std::sync::atomic::Ordering::Release);
+
+        let (text, newline) = text.split_at(text.len() - 1);
+        debug_assert_eq!(newline, "\n");
+
+        match level {
+            llama_cpp_sys_2::GGML_LOG_LEVEL_NONE => {
+                // TODO: Support logging this to stdout directly via options?
+                tracing::info!(no_log_level = true, text);
+            }
+            llama_cpp_sys_2::GGML_LOG_LEVEL_DEBUG
+            | llama_cpp_sys_2::GGML_LOG_LEVEL_INFO
+            | llama_cpp_sys_2::GGML_LOG_LEVEL_WARN
+            | llama_cpp_sys_2::GGML_LOG_LEVEL_ERROR => Self::generate_log(self.module, level, text),
+            llama_cpp_sys_2::GGML_LOG_LEVEL_CONT => unreachable!(),
+            _ => {
+                tracing::warn!(
+                    level = level,
+                    text = text,
+                    origin = "crate",
+                    "Unknown llama.cpp log level"
+                )
+            }
+        }
+    }
+}
+
+pub(super) static LLAMA_STATE: OnceLock<Box<State>> = OnceLock::new();
+pub(super) static GGML_STATE: OnceLock<Box<State>> = OnceLock::new();

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -63,6 +63,7 @@ bindgen = { workspace = true }
 cc = { workspace = true, features = ["parallel"] }
 cmake = "0.1"
 glob = "0.3.2"
+walkdir = "2"
 
 [features]
 cuda = []

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -166,6 +166,10 @@ fn main() {
         .map(|v| v == "1")
         .unwrap_or(false);
 
+    println!("cargo:rerun-if-env-changed=LLAMA_LIB_PROFILE");
+    println!("cargo:rerun-if-env-changed=LLAMA_BUILD_SHARED_LIBS");
+    println!("cargo:rerun-if-env-changed=LLAMA_STATIC_CRT");
+
     debug_log!("TARGET: {}", target);
     debug_log!("CARGO_MANIFEST_DIR: {}", manifest_dir);
     debug_log!("TARGET_DIR: {}", target_dir.display());

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -1,5 +1,6 @@
 use cmake::Config;
 use glob::glob;
+use walkdir::DirEntry;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -26,27 +27,6 @@ fn get_cargo_target_dir() -> Result<std::path::PathBuf, Box<dyn std::error::Erro
     }
     let target_dir = target_dir.ok_or("not found")?;
     Ok(target_dir.to_path_buf())
-}
-
-fn copy_folder(src: &Path, dst: &Path) {
-    std::fs::create_dir_all(dst).expect("Failed to create dst directory");
-    if cfg!(unix) {
-        std::process::Command::new("cp")
-            .arg("-rf")
-            .arg(src)
-            .arg(dst.parent().unwrap())
-            .status()
-            .expect("Failed to execute cp command");
-    }
-
-    if cfg!(windows) {
-        std::process::Command::new("robocopy.exe")
-            .arg("/e")
-            .arg(src)
-            .arg(dst)
-            .status()
-            .expect("Failed to execute robocopy command");
-    }
 }
 
 fn extract_lib_names(out_dir: &Path, build_shared_libs: bool) -> Vec<String> {
@@ -148,12 +128,17 @@ fn macos_link_search_path() -> Option<String> {
     None
 }
 
+fn is_hidden(e: &DirEntry) -> bool {
+    e.file_name().to_str().map(|s| s.starts_with('.')).unwrap_or_default()
+}
+
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
     let target = env::var("TARGET").unwrap();
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let target_dir = get_cargo_target_dir().unwrap();
-    let llama_dst = out_dir.join("llama.cpp");
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("Failed to get CARGO_MANIFEST_DIR");
     let llama_src = Path::new(&manifest_dir).join("llama.cpp");
     let build_shared_libs = cfg!(feature = "cuda") || cfg!(feature = "dynamic-link");
@@ -176,11 +161,20 @@ fn main() {
     debug_log!("OUT_DIR: {}", out_dir.display());
     debug_log!("BUILD_SHARED: {}", build_shared_libs);
 
-    // Prepare sherpa-onnx source
-    if !llama_dst.exists() {
-        debug_log!("Copy {} to {}", llama_src.display(), llama_dst.display());
-        copy_folder(&llama_src, &llama_dst);
+    // Make sure that changes to the llama.cpp project trigger a rebuild.
+    let rebuild_on_children_of = [
+        llama_src.join("src"),
+        llama_src.join("ggml/src"),
+        llama_src.join("common"),
+    ];
+    for entry in walkdir::WalkDir::new(&llama_src).into_iter().filter_entry(|e| !is_hidden(e)) {
+        let entry = entry.expect("Failed to obtain entry");
+        let rebuild = entry.file_name().to_str().map(|f| f.starts_with("CMake")).unwrap_or_default() || rebuild_on_children_of.iter().any(|src_folder| entry.path().starts_with(src_folder));
+        if rebuild {
+            println!("cargo:rerun-if-changed={}", entry.path().display());
+        }
     }
+
     // Speed up build
     env::set_var(
         "CMAKE_BUILD_PARALLEL_LEVEL",
@@ -193,8 +187,8 @@ fn main() {
     // Bindings
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_arg(format!("-I{}", llama_dst.join("include").display()))
-        .clang_arg(format!("-I{}", llama_dst.join("ggml/include").display()))
+        .clang_arg(format!("-I{}", llama_src.join("include").display()))
+        .clang_arg(format!("-I{}", llama_src.join("ggml/include").display()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .derive_partialeq(true)
         .allowlist_function("ggml_.*")
@@ -212,13 +206,12 @@ fn main() {
         .expect("Failed to write bindings");
 
     println!("cargo:rerun-if-changed=wrapper.h");
-    println!("cargo:rerun-if-changed=./sherpa-onnx");
 
     debug_log!("Bindings Created");
 
     // Build with Cmake
 
-    let mut config = Config::new(&llama_dst);
+    let mut config = Config::new(&llama_src);
 
     // Would require extra source files to pointlessly
     // be included in what's uploaded to and downloaded from


### PR DESCRIPTION
After this change, if you don't pass --verbose, you'll see that simple.exe doesn't print anything from llama.cpp If you do, the logs are formatted through the tracing module. This resolves issues #628 

```
     Running `target\debug\simple.exe --verbose --prompt Hello hf-model hugging-quants/Llama-3.2-3B-Instruct-Q8_0-GGUF llama-3.2-3b-instruct-q8_0.gguf`
2025-02-05T04:19:14.536931Z  INFO hf_hub: Token file not found "C:\\Users\\vlovich\\.cache\\huggingface\\token"
2025-02-05T04:19:14.542020Z DEBUG load_from_file: llama-cpp-2: registered backend CPU (1 devices) module="ggml::register_backend"
2025-02-05T04:19:14.542195Z DEBUG load_from_file: llama-cpp-2: registered device CPU (AMD Ryzen 9 7845HX with Radeon Graphics        ) module="ggml::register_device"
2025-02-05T04:19:14.631339Z  INFO load_from_file: llama-cpp-2: loaded meta data with 30 key-value pairs and 255 tensors from C:\Users\vlovich\.cache\huggingface\hub\models--hugging-quants--Llama-3.2-3B-Instruct-Q8_0-GGUF\snapshots\7ef7efff7d2c14e5d6161a0c7006e1f2fea6ec79\llama-3.2-3b-instruct-q8_0.gguf (version GGUF V3 (latest)) module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.631581Z  INFO load_from_file: llama-cpp-2: Dumping metadata keys/values. Note: KV overrides do not apply in this output. module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.631727Z  INFO load_from_file: llama-cpp-2: - kv   0:                       general.architecture str              = llama module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.631842Z  INFO load_from_file: llama-cpp-2: - kv   1:                               general.type str              = model module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.631923Z  INFO load_from_file: llama-cpp-2: - kv   2:                               general.name str              = Llama 3.2 3B Instruct module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632005Z  INFO load_from_file: llama-cpp-2: - kv   3:                           general.finetune str              = Instruct module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632052Z  INFO load_from_file: llama-cpp-2: - kv   4:                           general.basename str              = Llama-3.2 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632097Z  INFO load_from_file: llama-cpp-2: - kv   5:                         general.size_label str              = 3B module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632171Z  INFO load_from_file: llama-cpp-2: - kv   6:                               general.tags arr[str,6]       = ["facebook", "meta", "pytorch", "llam... module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632232Z  INFO load_from_file: llama-cpp-2: - kv   7:                          general.languages arr[str,8]       = ["en", "de", "fr", "it", "pt", "hi", ... module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632282Z  INFO load_from_file: llama-cpp-2: - kv   8:                          llama.block_count u32              = 28 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632331Z  INFO load_from_file: llama-cpp-2: - kv   9:                       llama.context_length u32              = 131072 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632365Z  INFO load_from_file: llama-cpp-2: - kv  10:                     llama.embedding_length u32              = 3072 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632399Z  INFO load_from_file: llama-cpp-2: - kv  11:                  llama.feed_forward_length u32              = 8192 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632433Z  INFO load_from_file: llama-cpp-2: - kv  12:                 llama.attention.head_count u32              = 24 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632503Z  INFO load_from_file: llama-cpp-2: - kv  13:              llama.attention.head_count_kv u32              = 8 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632582Z  INFO load_from_file: llama-cpp-2: - kv  14:                       llama.rope.freq_base f32              = 500000.000000 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632628Z  INFO load_from_file: llama-cpp-2: - kv  15:     llama.attention.layer_norm_rms_epsilon f32              = 0.000010 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632666Z  INFO load_from_file: llama-cpp-2: - kv  16:                 llama.attention.key_length u32              = 128 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632702Z  INFO load_from_file: llama-cpp-2: - kv  17:               llama.attention.value_length u32              = 128 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632735Z  INFO load_from_file: llama-cpp-2: - kv  18:                          general.file_type u32              = 7 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632774Z  INFO load_from_file: llama-cpp-2: - kv  19:                           llama.vocab_size u32              = 128256 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632816Z  INFO load_from_file: llama-cpp-2: - kv  20:                 llama.rope.dimension_count u32              = 128 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632856Z  INFO load_from_file: llama-cpp-2: - kv  21:                       tokenizer.ggml.model str              = gpt2 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.632894Z  INFO load_from_file: llama-cpp-2: - kv  22:                         tokenizer.ggml.pre str              = llama-bpe module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.695145Z  INFO load_from_file: llama-cpp-2: - kv  23:                      tokenizer.ggml.tokens arr[str,128256]  = ["!", "\"", "#", "$", "%", "&", "'", ... module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.710077Z  INFO load_from_file: llama-cpp-2: - kv  24:                  tokenizer.ggml.token_type arr[i32,128256]  = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.846818Z  INFO load_from_file: llama-cpp-2: - kv  25:                      tokenizer.ggml.merges arr[str,280147]  = ["Ġ Ġ", "Ġ ĠĠĠ", "ĠĠ ĠĠ", "... module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847012Z  INFO load_from_file: llama-cpp-2: - kv  26:                tokenizer.ggml.bos_token_id u32              = 128000 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847146Z  INFO load_from_file: llama-cpp-2: - kv  27:                tokenizer.ggml.eos_token_id u32              = 128009 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847240Z  INFO load_from_file: llama-cpp-2: - kv  28:                    tokenizer.chat_template str              = {% set loop_messages = messages %}{% ... module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847355Z  INFO load_from_file: llama-cpp-2: - kv  29:               general.quantization_version u32              = 2 module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847446Z  INFO load_from_file: llama-cpp-2: - type  f32:   58 tensors module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847506Z  INFO load_from_file: llama-cpp-2: - type q8_0:  197 tensors module="llama.cpp::llama_model_loader"
2025-02-05T04:19:14.847572Z  INFO load_from_file: llama-cpp-2: file format = GGUF V3 (latest) module="llama.cpp::print_info"
2025-02-05T04:19:14.847630Z  INFO load_from_file: llama-cpp-2: file type   = Q8_0 module="llama.cpp::print_info"
2025-02-05T04:19:14.847698Z  INFO load_from_file: llama-cpp-2: file size   = 3.18 GiB (8.50 BPW)  module="llama.cpp::print_info"
2025-02-05T04:19:15.259516Z DEBUG load_from_file: llama-cpp-2: initializing tokenizer for type 2 module="llama.cpp::init_tokenizer"
2025-02-05T04:19:15.311221Z DEBUG load_from_file: llama-cpp-2: control token: 128098 '<|reserved_special_token_90|>' is not marked as EOG module="llama.cpp::load"
2025-02-05T04:19:15.311473Z DEBUG load_from_file: llama-cpp-2: control token: 128191 '<|reserved_special_token_183|>' is not marked as EOG module="llama.cpp::load"
2025-02-05T04:19:15.311779Z DEBUG load_from_file: llama-cpp-2: control token: 128130 '<|reserved_special_token_122|>' is not marked as EOG module="llama.cpp::load"
2025-02-05T04:19:15.312237Z DEBUG load_from_file: llama-cpp-2: control token: 128119 '<|reserved_special_token_111|>' is not marked as EOG module="llama.cpp::load"
2025-02-05T04:19:15.312319Z DEBUG load_from_file: llama-cpp-2: control token: 128136 '<|reserved_special_token_128|>' is not marked as EOG module="llama.cpp::load"
```