### PR TITLE
more reliable target directory estimation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
 resolver = "2"
 members = [
-    "llama-cpp-sys-2",
-    "llama-cpp-2",
-    "examples/embeddings",
-    "examples/simple", "examples/reranker",
+  "llama-cpp-sys-2",
+  "llama-cpp-2",
+  "examples/embeddings",
+  "examples/simple",
+  "examples/reranker",
 ]
 
 [workspace.dependencies]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2021"
 [dependencies]
 llama-cpp-2 = { path = "../../llama-cpp-2", version = "0.1.69" }
 hf-hub = { workspace = true }
-clap = { workspace = true , features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 encoding_rs = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]
 cuda = ["llama-cpp-2/cuda"]
-metal =  ["llama-cpp-2/metal"]
+metal = ["llama-cpp-2/metal"]
 native = ["llama-cpp-2/native"]
 vulkan = ["llama-cpp-2/vulkan"]
 


### PR DESCRIPTION
Currently, llama-cpp-rs fails with "not found" when compiling a project using a different profile.

For example, having this in our cargo toml:

```toml
[profile.dist]
lto = true
inherits = "release"
codegen-units = 1
panic = "abort"
strip = "debuginfo"

[profile.release]
opt-level = 3
```

Then compile like this: `cargo build --profile=dist` will fail because `PROFILE` is always "release"

The new way just goes back 3 steps which will always be the target (source: https://stackoverflow.com/a/73603419).