### PR TITLE
Fix llama.cpp build dirtying src and breaking packaging

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -315,6 +315,11 @@ fn main() {
         .always_configure(false);
 
     let build_dir = config.build();
+    std::fs::rename(
+        llama_src.join("common/build-info.cpp"),
+        build_dir.join("build-info.cpp"),
+    )
+    .unwrap();
 
     // Search paths
     println!("cargo:rustc-link-search={}", out_dir.join("lib").display());


### PR DESCRIPTION
Move the build-info.cpp to the output target after building to avoid polluting during packaging and causing verification to fail.

Turns out I didn't actually test dry-run the final version of the PR I pushed? Not sure what happened. This passes.