### PR TITLE
Cleanup chat template API

### DIFF
--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -10,7 +10,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use hf_hub::api::sync::ApiBuilder;
 use llama_cpp_2::context::params::LlamaContextParams;
-use llama_cpp_2::{ggml_time_us, send_logs_to_tracing, LogOptions};
 use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::kv_overrides::ParamOverrideValue;
@@ -18,6 +17,7 @@ use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::LlamaModel;
 use llama_cpp_2::model::{AddBos, Special};
 use llama_cpp_2::sampling::LlamaSampler;
+use llama_cpp_2::{ggml_time_us, send_logs_to_tracing, LogOptions};
 
 use std::ffi::CString;
 use std::io::Write;
@@ -67,11 +67,7 @@ struct Args {
         help = "size of the prompt context (default: loaded from themodel)"
     )]
     ctx_size: Option<NonZeroU32>,
-    #[arg(
-        short = 'v',
-        long,
-        help = "enable verbose llama.cpp logs",
-    )]
+    #[arg(short = 'v', long, help = "enable verbose llama.cpp logs")]
     verbose: bool,
 }
 

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -69,15 +69,18 @@ pub enum LLamaCppError {
 /// There was an error while getting the chat template from a model.
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ChatTemplateError {
-    /// the buffer was too small.
-    #[error("The buffer was too small. However, a buffer size of {0} would be just large enough.")]
-    BuffSizeError(usize),
     /// gguf has no chat template
     #[error("the model has no meta val - returned code {0}")]
     MissingTemplate(i32),
     /// The chat template was not valid utf8.
     #[error(transparent)]
     Utf8Error(#[from] std::str::Utf8Error),
+}
+
+enum InternalChatTemplateError {
+    Permanent(ChatTemplateError),
+    /// the buffer was too small.
+    RetryWithLargerBuffer(usize),
 }
 
 /// Failed to Load context

--- a/llama-cpp-2/src/log.rs
+++ b/llama-cpp-2/src/log.rs
@@ -171,7 +171,8 @@ impl State {
         } else {
             let level = self
                 .previous_level
-                .load(std::sync::atomic::Ordering::Acquire) as llama_cpp_sys_2::ggml_log_level;
+                .load(std::sync::atomic::Ordering::Acquire)
+                as llama_cpp_sys_2::ggml_log_level;
             tracing::warn!(
                 inferred_level = level,
                 text = text,


### PR DESCRIPTION
1. Make the template not an optional for apply_chat_template. This ensures you don't accidentally use the chatml template.
2. Improve performance for the expected case of using get_chat_template by returning a new LlamaChatTemplate struct that internally stores the string as a CString. Unless you try to explicitly create a copy or print, there's no extra copy into a Rust string that's created. Similarly, get_chat_template -> apply_chat_template no longer copies the template string.
3. Improve documentation including documentating what the add_ass parameter does and suggestions on what values you probably want to use. Additionally, I've made get_chat_template and apply_chat_template docs refer to one another to make it easier to discover how to use this.

This resolves https://github.com/utilityai/llama-cpp-rs/issues/640 and https://github.com/utilityai/llama-cpp-rs/issues/641

@MarcusDunn hope you don't mind, but instead of separate &str vs &CStr, I've instead created a new LlamaChatTemplate struct that internally stores the CString with convenience methods to easily retrieve &str/String from it or to construct it from a &str. I found that to be a bit cleaner.