### PR TITLE
Fix Android build

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -39,8 +39,6 @@ fn parse_target_os() -> Result<(TargetOs, String), String> {
         } else {
             Ok((TargetOs::Windows(WindowsVariant::Other), target))
         }
-    } else if target.contains("linux") {
-        Ok((TargetOs::Linux, target))
     } else if target.contains("apple") {
         if target.ends_with("-apple-darwin") {
             Ok((TargetOs::Apple(AppleVariant::MacOS), target))
@@ -49,6 +47,8 @@ fn parse_target_os() -> Result<(TargetOs, String), String> {
         }
     } else if target.contains("android") {
         Ok((TargetOs::Android, target))
+    } else if target.contains("linux") {
+        Ok((TargetOs::Linux, target))
     } else {
         Err(target)
     }


### PR DESCRIPTION
Android's triple is `<arch>-linux-android`. Move the detection of Android above Linux as otherwise Android builds are detected as plain vanilla Linux & break because they try to leverage OpenMP.