### PR TITLE
Make LogOptions public

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -331,7 +331,7 @@ pub fn llama_supports_mlock() -> bool {
 /// Options to configure how llama.cpp logs are intercepted.
 #[derive(Default, Debug, Clone)]
 pub struct LogOptions {
-    disabled: bool,
+    pub disabled: bool,
 }
 
 impl LogOptions {


### PR DESCRIPTION
I can't construct LogOptions because its members are private.
In order to use `send_logs_to_tracing`, those are needed to public.
This pull request fixes it.