### PR TITLE
Explicitly apply optimization flags to msvc compiler also on other profiles than debug

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -277,10 +277,7 @@ fn main() {
         config.define("GGML_BLAS", "OFF");
     }
 
-    if (cfg!(debug_assertions)
-        || std::env::var("PROFILE").as_ref().map(String::as_str) == Ok("debug"))
-        && matches!(target_os, TargetOs::Windows(WindowsVariant::Msvc))
-        && profile == "Release"
+    if (matches!(target_os, TargetOs::Windows(WindowsVariant::Msvc)) && matches!(profile.as_str(), "Release" | "RelWithDebInfo" | "MinSizeRel"))
     {
         // Debug Rust builds under MSVC turn off optimization even though we're ideally building the release profile of llama.cpp.
         // Looks like an upstream bug:


### PR DESCRIPTION
See #649 for discussion.

Before this PR, release builds for x86_64-pc-windows-msvc were significantly slower than debug builds.

This is all because of a bug in cmake-rs.

With this PR, release profile builds also get the optimization flags passed into msvc explicitly.

This workaround may no longer be necessary if the relevant fixes get applied to cmake-rs.