### PR TITLE
Use CString::new instead of CString::from_str to init chat template

### DIFF
--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU16;
 use std::os::raw::c_int;
 use std::path::Path;
 use std::ptr::NonNull;
-use std::str::{FromStr, Utf8Error};
+use std::str::Utf8Error;
 
 use crate::context::params::LlamaContextParams;
 use crate::context::LlamaContext;
@@ -47,7 +47,7 @@ impl LlamaChatTemplate {
     /// Create a new template from a string. This can either be the name of a llama.cpp [chat template](https://github.com/ggerganov/llama.cpp/blob/8a8c4ceb6050bd9392609114ca56ae6d26f5b8f5/src/llama-chat.cpp#L27-L61)
     /// like "chatml" or "llama3" or an actual Jinja template for llama.cpp to interpret.
     pub fn new(template: &str) -> Result<Self, std::ffi::NulError> {
-        Ok(Self(CString::from_str(template)?))
+        Ok(Self(CString::new(template)?))
     }
 
     /// Accesses the template as a c string reference.


### PR DESCRIPTION
Not sure what happened here but:

`cargo build` fails for me on the current `main` branch. It seems like CString doesn't implement `from_str()`

```
error[E0599]: no function or associated item named `from_str` found for struct `CString` in the current scope
   --> llama-cpp-2/src/model.rs:50:26
    |
50  |         Ok(Self(CString::from_str(template)?))
    |                          ^^^^^^^^ function or associated item not found in `CString`
    |
```

This PR just changes it to `CString::new()` which seems to have the same type signature and behavior.

I guess it could be a thing about rust std versions?

My `rustup show` says the following, so it doesn't seem like I'm running anything unusual.

```
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/asbjorn/.rustup

installed toolchains
--------------------

stable-x86_64-unknown-linux-gnu (default)
nightly-x86_64-unknown-linux-gnu

installed targets for active toolchain
--------------------------------------

aarch64-linux-android
x86_64-pc-windows-gnu
x86_64-unknown-linux-gnu

active toolchain
----------------

stable-x86_64-unknown-linux-gnu (default)
rustc 1.85.0 (4d91de4e4 2025-02-17)
```

I can't really explain why this works in your CI, but not on my machine- but it seems like a pretty uncontroversial change.