### PR TITLE
Fix to check if events should be recorded in tracing

### DIFF
--- a/llama-cpp-2/src/log.rs
+++ b/llama-cpp-2/src/log.rs
@@ -142,16 +142,18 @@ impl State {
         let (meta, fields) = meta_for_level(level);
 
         tracing::dispatcher::get_default(|dispatcher| {
-            dispatcher.event(&tracing::Event::new(
-                meta,
-                &meta.fields().value_set(&[
-                    (&fields.message, Some(&text as &dyn tracing::field::Value)),
-                    (
-                        &fields.target,
-                        module.as_ref().map(|s| s as &dyn tracing::field::Value),
-                    ),
-                ]),
-            ));
+            if dispatcher.enabled(meta) {
+                dispatcher.event(&tracing::Event::new(
+                    meta,
+                    &meta.fields().value_set(&[
+                        (&fields.message, Some(&text as &dyn tracing::field::Value)),
+                        (
+                            &fields.target,
+                            module.as_ref().map(|s| s as &dyn tracing::field::Value),
+                        ),
+                    ]),
+                ));
+            }
         });
     }
 


### PR DESCRIPTION
I can't filter logs from llama-cpp-2 ( I can from llama_cpp_2 ).
```rust
let env_filter = EnvFilter::builder()
    .with_default_directive(filter::LevelFilter::TRACE.into())
    .from_env()
    .unwrap()
    .add_directive("llama_cpp_2=error".parse().unwrap())
    .add_directive("llama-cpp-2=error".parse().unwrap());
let layer = fmt::layer().compact().with_line_number(true);
tracing_subscriber::registry()
    .with(layer)
    .with(env_filter)
    .init();
```
By manually checking it, you can filter logs from llama-cpp-2.