### PR TITLE
Fix build.rs: copy build_info_src into build_info_target

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -379,7 +379,7 @@ fn main() {
     std::fs::rename(&build_info_src,&build_info_target).unwrap_or_else(|move_e| {
         // Rename may fail if the target directory is on a different filesystem/disk from the source.
         // Fall back to copy + delete to achieve the same effect in this case.
-        std::fs::copy(&build_info_src, &build_info_src).unwrap_or_else(|copy_e| {
+        std::fs::copy(&build_info_src, &build_info_target).unwrap_or_else(|copy_e| {
             panic!("Failed to rename {build_info_src:?} to {build_info_target:?}. Move failed with {move_e:?} and copy failed with {copy_e:?}");
         });
         std::fs::remove_file(&build_info_src).unwrap_or_else(|e| {


### PR DESCRIPTION
So on windows github actions runners, source and target dirs are on different disks.

This led to an error which was fixed by #655 

Problem is, the fallback tries to copy build_info_src into build_info_src.

This fails (at least on windows) with the error "The process cannot access the file because it is being used by another process."

This error is easy to miss, and the fix is helpfully obvious.