### PR TITLE
Expose n_head_kv

### DIFF
--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -484,6 +484,13 @@ impl LlamaModel {
         u32::try_from(unsafe { llama_cpp_sys_2::llama_model_n_head(self.model.as_ptr()) }).unwrap()
     }
 
+    /// Returns the number of KV attention heads.
+    pub fn n_head_kv(&self) -> u32 {
+        // It's never possible for this to panic because while the API interface is defined as an int32_t,
+        // the field it's accessing is a uint32_t.
+        u32::try_from(unsafe { llama_cpp_sys_2::llama_model_n_head_kv(self.model.as_ptr()) }).unwrap()
+    }
+
     /// Returns the rope type of the model.
     pub fn rope_type(&self) -> Option<RopeType> {
         match unsafe { llama_cpp_sys_2::llama_model_rope_type(self.model.as_ptr()) } {


### PR DESCRIPTION
It's in upstream so bump the to latest llama.cpp & plumb through the API.