### PR TITLE
Expose string metadata fetching methods

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -82,6 +82,21 @@ pub enum ChatTemplateError {
     Utf8Error(#[from] std::str::Utf8Error),
 }
 
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum MetaValError {
+    #[error("model does not have metadata key: {0}")]
+    MissingKey(String),
+
+    #[error("null byte in string {0}")]
+    NullError(#[from] NulError),
+
+    #[error("FromUtf8Error {0}")]
+    FromUtf8Error(#[from] FromUtf8Error),
+
+    #[error("Negative return value. Likely due to a missing index or key. Got return value: {0}")]
+    NegativeReturn(i32),
+}
+
 /// Failed to Load context
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum LlamaContextLoadError {

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -82,17 +82,18 @@ pub enum ChatTemplateError {
     Utf8Error(#[from] std::str::Utf8Error),
 }
 
+/// Failed fetching metadata value
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum MetaValError {
-    #[error("model does not have metadata key: {0}")]
-    MissingKey(String),
-
+    /// The provided string contains an unexpected null-byte
     #[error("null byte in string {0}")]
     NullError(#[from] NulError),
 
+    /// The returned data contains invalid UTF8 data
     #[error("FromUtf8Error {0}")]
     FromUtf8Error(#[from] FromUtf8Error),
 
+    /// Got negative return value. This happens if the key or index queried does not exist.
     #[error("Negative return value. Likely due to a missing index or key. Got return value: {0}")]
     NegativeReturn(i32),
 }


### PR DESCRIPTION
Specifically, it implements these functions (excerpt from llama.h):

```c++
    // Functions to access the model's GGUF metadata scalar values
    // - The functions return the length of the string on success, or -1 on failure
    // - The output string is always null-terminated and cleared on failure
    // - When retrieving a string, an extra byte must be allocated to account for the null terminator
    // - GGUF array values are not supported by these functions

    // Get metadata value as a string by key name
    LLAMA_API int32_t llama_model_meta_val_str(const struct llama_model * model, const char * key, char * buf, size_t buf_size);

    // Get the number of metadata key/value pairs
    LLAMA_API int32_t llama_model_meta_count(const struct llama_model * model);

    // Get metadata key name by index
    LLAMA_API int32_t llama_model_meta_key_by_index(const struct llama_model * model, int32_t i, char * buf, size_t buf_size);

    // Get metadata value as a string by index
    LLAMA_API int32_t llama_model_meta_val_str_by_index(const struct llama_model * model, int32_t i, char * buf, size_t buf_size);
```

I tested it using a quick script that looks like this:

```rust
use llama_cpp_2::llama_backend::LlamaBackend;
use llama_cpp_2::model::LlamaModel;
use llama_cpp_2::model::params::LlamaModelParams;

fn main() {
    let args: Vec<String> = std::env::args().collect();
    if args.len() < 2 {
        println!("Remember to pass a model path, you doofus!");
    }
    let model_path = &args[1];

    let backend = LlamaBackend::init().expect("Failed to initialize llama backend");
    let params = LlamaModelParams::default();
    let model =
        LlamaModel::load_from_file(&backend, model_path, &params).expect("Failed loading model");

    for i in 0..model.meta_count() {
        let key = model
            .meta_key_by_index(i)
            .expect("Could not find key at index");

        if key.starts_with("tokenizer.chat_template") {
            println!("--- {key} ---");
            let template = model
                .meta_val_str_by_index(i)
                .expect("Could not find value at index");
            let test_templ = model
                .meta_val_str(&key)
                .expect("Could not find value at key");
            assert_eq!(template, test_templ);
            println!("{template}");
        }
    }
}
```