### PR TITLE
Add llama-grammar.h for bindgen

### DIFF
--- a/llama-cpp-sys-2/wrapper.h
+++ b/llama-cpp-sys-2/wrapper.h
@@ -1,1 +1,2 @@
 #include "llama.cpp/include/llama.h"
+#include "llama.cpp/src/llama-grammar.h"


### PR DESCRIPTION
Having `llama-grammar` is super usful, for ex, validating GBNF (https://github.com/ggml-org/llama.cpp/blob/master/examples/gbnf-validator/gbnf-validator.cpp).