### PR TITLE
Bump llama.cpp, disable CURL

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -267,6 +267,7 @@ fn main() {
     config.define("LLAMA_BUILD_TESTS", "OFF");
     config.define("LLAMA_BUILD_EXAMPLES", "OFF");
     config.define("LLAMA_BUILD_SERVER", "OFF");
+    config.define("LLAMA_CURL", "OFF");
 
     config.define(
         "BUILD_SHARED_LIBS",


### PR DESCRIPTION
Sets LLAMA_CURL=OFF in build.rs.

Currently, llama-cpp-rs will fail to build on more recent commits of llama.cpp, if the libcurl libraries aren't installed, since LLAMA_CURL has changed defaults to being on by default.

If I am not mistaken, curl is only used in common.h, which is considered out of scope for this library, so we might as well disable it always.

This also bumps the version of llama.cpp to the most recent, which adds support for qwen3, closing #719 