### PR TITLE
Add llama backend init to the doc tests that depend on it

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -217,6 +217,8 @@ pub enum LlamaLoraAdapterRemoveError {
 /// get the time (in microseconds) according to llama.cpp
 /// ```
 /// # use llama_cpp_2::llama_time_us;
+/// # use llama_cpp_2::llama_backend::LlamaBackend;
+/// let backend = LlamaBackend::init().unwrap();
 /// let time = llama_time_us();
 /// assert!(time > 0);
 /// ```
@@ -311,6 +313,8 @@ pub enum ApplyChatTemplateError {
 ///
 /// ```
 /// # use std::time::Duration;
+/// # use llama_cpp_2::llama_backend::LlamaBackend;
+/// let backend = LlamaBackend::init().unwrap();
 /// use llama_cpp_2::ggml_time_us;
 ///
 /// let start = ggml_time_us();

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -117,6 +117,8 @@ impl LlamaSampler {
     ///    data_array::LlamaTokenDataArray
     /// };
     /// use llama_cpp_2::sampling::LlamaSampler;
+    /// use llama_cpp_2::llama_backend::LlamaBackend;
+    /// let backend = LlamaBackend::init().unwrap();
     ///
     /// let mut data_array = LlamaTokenDataArray::new(vec![
     ///     LlamaTokenData::new(LlamaToken(0), 0., 0.),


### PR DESCRIPTION
Three tests were failing, on windows, in github actions: `llama_time_us`, `ggml_time_us`, and `chain_simple`.

The first two are actually the same thing. `llama_time_us` is in effect just a rename of `ggml_time_us`. `ggml_time_init` needs to be called before `ggml_time_us` will work. `ggml_time_init` isn't exposed by llama-cpp-2, but `LlamaBackend::init` will call it. I added that to the tests that failed before.

There is a similar thing going on with the sampler test: not sure exactly what, but initializing the LlamaBackend fixes it.