### PR TITLE
Fix MacOS 15 build

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -237,6 +237,7 @@ fn main() {
         .header("wrapper.h")
         .clang_arg(format!("-I{}", llama_src.join("include").display()))
         .clang_arg(format!("-I{}", llama_src.join("ggml/include").display()))
+        .clang_arg(format!("--target={}", env::var("HOST").unwrap()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .derive_partialeq(true)
         .allowlist_function("ggml_.*")


### PR DESCRIPTION
Build `llama-cpp-sys-2` on MacOS 15.5 failed with `Unsupported architecture` error because `build.rs` doesn't set target when calling bindgen.
