### PR TITLE
Fix: GCC Target Mismatch for `vdotq_s32` on AArch64 (Apple M1, M2, etc)

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -336,6 +336,16 @@ fn main() {
         }
     }
 
+    if matches!(target_os, TargetOs::Linux)
+        && target_triple.contains("aarch64")
+        && !env::var(format!("CARGO_FEATURE_{}", "native".to_uppercase())).is_ok()
+    {
+        // If the native feature is not enabled, we take off the native ARM64 support.
+        // It is useful in docker environments where the native feature is not enabled.
+        config.define("GGML_NATIVE", "OFF");
+        config.define("GGML_CPU_ARM_ARCH", "armv8-a");
+    }
+
     if cfg!(feature = "vulkan") {
         config.define("GGML_VULKAN", "ON");
         match target_os {


### PR DESCRIPTION
## Problem

Building `llama.cpp` on AArch64 (e.g. in Docker on macOS M1/M2) fails when compiling NEON dot product code using `vdotq_s32`. GCC throws the following error:

```
error: inlining failed in call to 'always_inline' 'int32x4_t vdotq_s32(...)': target specific option mismatch
```

This error occurs because `vdotq_s32` requires the ARMv8.x-A dot product extension (`+dotprod`), which is not enabled by default in most toolchains.

This PR disables GGML's use of native optimizations as a temporary fix, without modifying `llama.cpp` directly. Since Apple Silicon CPUs may not be a primary target for the llama.cpp project, this workaround allows successful builds.

Feel free to close this PR if it does not apply to your use case.