### PR TITLE
Bump llama.cpp to b5686, fix build failures

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -24,18 +24,6 @@ include = [
 
     "/llama.cpp/convert_hf_to_gguf.py", # Yes, it's required
 
-    # Erroneously the llama.cpp code currently generates the build-info.cpp
-    # into the source directory of the build instead of into the target directory
-    # as it should. Will try submitting something upstream to clean this up as
-    # well but for now explictly exclude this from the build. Previously this was
-    # implicitly excluded because the llama.cpp code was copied wholesale into the
-    # target directory for building which is why this problem wasn't visible before
-    # (i.e. we'd package the llama.cpp source from the submodule & thus this build-info.cpp
-    # generated file would still be ignored because it would only exist in the separate
-    # copy within the target directory. An alternative, if we do want to capture build-info.cpp
-    # within the package would be to change the CI task to add `--allow-dirty` to the package
-    # command.
-    "!/llama.cpp/common/build-info.cpp",
     "/llama.cpp/common/build-info.cpp.in",
 
     "/llama.cpp/ggml/src/ggml-cuda.cu",

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -388,18 +388,6 @@ fn main() {
         .always_configure(false);
 
     let build_dir = config.build();
-    let build_info_src = llama_src.join("common/build-info.cpp");
-    let build_info_target = build_dir.join("build-info.cpp");
-    std::fs::rename(&build_info_src,&build_info_target).unwrap_or_else(|move_e| {
-        // Rename may fail if the target directory is on a different filesystem/disk from the source.
-        // Fall back to copy + delete to achieve the same effect in this case.
-        std::fs::copy(&build_info_src, &build_info_target).unwrap_or_else(|copy_e| {
-            panic!("Failed to rename {build_info_src:?} to {build_info_target:?}. Move failed with {move_e:?} and copy failed with {copy_e:?}");
-        });
-        std::fs::remove_file(&build_info_src).unwrap_or_else(|e| {
-            panic!("Failed to delete {build_info_src:?} after copying to {build_info_target:?}: {e:?} (move failed because {move_e:?})");
-        });
-    });
 
     // Search paths
     println!("cargo:rustc-link-search={}", out_dir.join("lib").display());

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -440,6 +440,7 @@ fn main() {
 
     match target_os {
         TargetOs::Windows(WindowsVariant::Msvc) => {
+            println!("cargo:rustc-link-lib=advapi32");
             if cfg!(debug_assertions) {
                 println!("cargo:rustc-link-lib=dylib=msvcrtd");
             }


### PR DESCRIPTION
The main motivation for bumping llama.cpp is to close #747 

In the meantime, there were some changes to the build-info.cpp generation. This caused a failure during the copy operation in build.rs.
Just removing the entire copy step seems to work. So I did that.