### PR TITLE
Do not set target through clang_arg

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -265,7 +265,6 @@ fn main() {
         .header("wrapper.h")
         .clang_arg(format!("-I{}", llama_src.join("include").display()))
         .clang_arg(format!("-I{}", llama_src.join("ggml/include").display()))
-        .clang_arg(format!("--target={}", target_triple))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .derive_partialeq(true)
         .allowlist_function("ggml_.*")
@@ -383,7 +382,6 @@ fn main() {
 
         // Configure bindgen for Android
         bindings_builder = bindings_builder
-            .clang_arg(format!("--target={}", target_triple))
             .clang_arg(format!("--sysroot={}", sysroot))
             .clang_arg(format!("-D__ANDROID_API__={}", android_api))
             .clang_arg("-D__ANDROID__");


### PR DESCRIPTION
Some architecture triples differ between rust and clang and require specific mapping logic. bindgen has special logic for that, which is circumvented by llama-cpp-sys-2 when setting the target through clang_arg directly. 

See https://github.com/rust-lang/rust-bindgen/blob/de9627ffa4860c6ed56cd40470fc7a96afc09d44/bindgen/lib.rs#L683 
See https://github.com/rust-lang/rust-bindgen/issues/1211

I also validated that building on macos 15.6 still works. 
