### PR TITLE
Prevent CUDA and Vulkan incompatibility in `examples/reranker` by adding the expected `disable_gpu` arg

### DIFF
--- a/examples/reranker/src/main.rs
+++ b/examples/reranker/src/main.rs
@@ -1,4 +1,4 @@
-//! This is a translation of embedding.cpp in llama.cpp using llama-cpp-2.
+//! This is an example of reranking documents for a query using llama-cpp-2.
 #![allow(
     clippy::cast_possible_wrap,
     clippy::cast_possible_truncation,
@@ -45,6 +45,11 @@ struct Args {
     /// Whether to normalise the produced embeddings
     #[clap(long, default_value_t = true)]
     normalise: bool,
+
+    /// Disable offloading layers to the gpu
+    #[cfg(any(feature = "cuda", feature = "vulkan"))]
+    #[clap(long)]
+    disable_gpu: bool,
 }
 
 fn main() -> Result<()> {
@@ -54,6 +59,8 @@ fn main() -> Result<()> {
         documents,
         pooling,
         normalise,
+        #[cfg(any(feature = "cuda", feature = "vulkan"))]
+        disable_gpu,
     } = Args::parse();
 
     // init LLM


### PR DESCRIPTION
This fixes:
```rs
error[E0425]: cannot find value `disable_gpu` in this scope
  --> examples\reranker\src\main.rs:65:13
   |
65 |         if !disable_gpu {
   |             ^^^^^^^^^^^ not found in this scope
```

when running `cargo build --features vulkan` (or `cuda` but that's not on my system) in the workspace.
