### PR TITLE
fix: dynamic tools CMakeLists.txt for selective MTMD building

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -55,6 +55,9 @@ include = [
     "/llama.cpp/cmake",
     "/llama.cpp/ggml/cmake",
     "/llama.cpp/common/cmake",
+
+    # Required for MTMD feature (specific tool only)
+    "/llama.cpp/tools/mtmd/CMakeLists.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -1,6 +1,7 @@
 use cmake::Config;
 use glob::glob;
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use walkdir::DirEntry;
@@ -195,6 +196,50 @@ fn is_hidden(e: &DirEntry) -> bool {
         .to_str()
         .map(|s| s.starts_with('.'))
         .unwrap_or_default()
+}
+
+/// Generate a dynamic tools CMakeLists.txt based on enabled features
+/// This approach allows each feature branch to add their own tool without conflicts
+fn generate_tools_cmake() {
+    let mut cmake_content = String::from(
+r#"# Auto-generated tools CMakeLists.txt based on enabled features
+# This file is created dynamically to only build tools for enabled features
+
+# dependencies
+find_package(Threads REQUIRED)
+
+# third-party
+# ...
+
+# flags
+llama_add_compile_flags()
+
+# tools - only build what's needed based on enabled features
+if (NOT EMSCRIPTEN)
+"#);
+
+    // Add tools based on enabled features
+    if cfg!(feature = "mtmd") {
+        cmake_content.push_str("    add_subdirectory(mtmd)\n");
+    }
+    
+    // Future feature branches can add their tools here:
+    // if cfg!(feature = "rpc") {
+    //     cmake_content.push_str("    add_subdirectory(rpc)\n");
+    // }
+    // if cfg!(feature = "server") {
+    //     cmake_content.push_str("    add_subdirectory(server)\n");
+    // }
+    // if cfg!(feature = "quantize") {
+    //     cmake_content.push_str("    add_subdirectory(quantize)\n");
+    // }
+
+    cmake_content.push_str("endif()\n");
+    
+    // Write the generated CMakeLists.txt
+    let tools_cmake_path = Path::new("llama.cpp/tools/CMakeLists.txt");
+    fs::write(tools_cmake_path, cmake_content)
+        .expect("Failed to write generated tools CMakeLists.txt");
 }
 
 fn main() {
@@ -448,10 +493,20 @@ fn main() {
     config.define("LLAMA_BUILD_TOOLS", "OFF");
     config.define("LLAMA_CURL", "OFF");
 
-    if cfg!(feature = "mtmd") {
+    // Generate dynamic tools CMakeLists.txt based on enabled tool features
+    let any_tool_features = cfg!(feature = "mtmd")
+        // Future tool features can be added here by other branches:
+        // || cfg!(feature = "rpc")
+        // || cfg!(feature = "server")
+        // || cfg!(feature = "quantize")
+        ;
+    
+    if any_tool_features {
         config.define("LLAMA_BUILD_COMMON", "ON");
-        // mtmd support in llama-cpp is within the tools directory
         config.define("LLAMA_BUILD_TOOLS", "ON");
+        
+        // Generate the tools CMakeLists.txt with only enabled features
+        generate_tools_cmake();
     }
 
     // Pass CMAKE_ environment variables down to CMake


### PR DESCRIPTION
## Summary
- Fixes MTMD build issue identified in PR #806 by implementing dynamic tools CMakeLists.txt generation
- Only builds MTMD tool when `mtmd` feature is enabled, avoiding building all 15+ unnecessary tools
- Creates scalable foundation for other tool features (RPC, server, quantize) to extend cleanly

## Key Changes
- **Dynamic CMakeLists.txt generation**: `generate_tools_cmake()` creates tools/CMakeLists.txt at build time based on enabled features
- **Selective building**: Only builds tools for enabled features instead of all tools
- **Merge-friendly architecture**: Clear extension points for other feature branches to add their tools
- **Backward compatible**: Existing MTMD functionality unchanged, just faster builds

## Technical Implementation  
- Replaces static CMakeLists.txt with dynamic generation in build.rs
- Uses feature flags to determine which tools to include
- Provides commented template for future tool features
- Eliminates need for including top-level tools/CMakeLists.txt that builds everything

## Benefits
- ✅ **Fixes build error** when `mtmd` feature enabled
- ✅ **Faster builds** - no more compiling unused tools  
- ✅ **Smaller binary** - only includes needed functionality
- ✅ **Future-proof** - easy for other branches to extend

## Test Plan
- [x] Builds successfully with `cargo build --features mtmd`  
- [x] Builds successfully without mtmd feature (no tools built)
- [x] MTMD functionality works as expected
- [x] No breaking changes to existing API

Resolves #806

🤖 Generated with [Claude Code](https://claude.ai/code)