### PR TITLE
Add KV cache type (K/V) configuration to LlamaContextParams

### DIFF
--- a/llama-cpp-2/src/context/params.rs
+++ b/llama-cpp-2/src/context/params.rs
@@ -88,6 +88,130 @@ impl From<LlamaPoolingType> for i32 {
     }
 }
 
+/// A rusty wrapper around `ggml_type` for KV cache types.
+#[allow(non_camel_case_types, missing_docs)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum KvCacheType {
+    /// Represents an unknown or not-yet-mapped `ggml_type` and carries the raw value.
+    /// When passed through FFI, the raw value is used as-is (if llama.cpp supports it,
+    /// the runtime will operate with that type).
+    /// This variant preserves API compatibility when new `ggml_type` values are
+    /// introduced in the future.
+    Unknown(llama_cpp_sys_2::ggml_type),
+    F32,
+    F16,
+    Q4_0,
+    Q4_1,
+    Q5_0,
+    Q5_1,
+    Q8_0,
+    Q8_1,
+    Q2_K,
+    Q3_K,
+    Q4_K,
+    Q5_K,
+    Q6_K,
+    Q8_K,
+    IQ2_XXS,
+    IQ2_XS,
+    IQ3_XXS,
+    IQ1_S,
+    IQ4_NL,
+    IQ3_S,
+    IQ2_S,
+    IQ4_XS,
+    I8,
+    I16,
+    I32,
+    I64,
+    F64,
+    IQ1_M,
+    BF16,
+    TQ1_0,
+    TQ2_0,
+    MXFP4,
+}
+
+impl From<KvCacheType> for llama_cpp_sys_2::ggml_type {
+    fn from(value: KvCacheType) -> Self {
+        match value {
+            KvCacheType::Unknown(raw) => raw,
+            KvCacheType::F32 => llama_cpp_sys_2::GGML_TYPE_F32,
+            KvCacheType::F16 => llama_cpp_sys_2::GGML_TYPE_F16,
+            KvCacheType::Q4_0 => llama_cpp_sys_2::GGML_TYPE_Q4_0,
+            KvCacheType::Q4_1 => llama_cpp_sys_2::GGML_TYPE_Q4_1,
+            KvCacheType::Q5_0 => llama_cpp_sys_2::GGML_TYPE_Q5_0,
+            KvCacheType::Q5_1 => llama_cpp_sys_2::GGML_TYPE_Q5_1,
+            KvCacheType::Q8_0 => llama_cpp_sys_2::GGML_TYPE_Q8_0,
+            KvCacheType::Q8_1 => llama_cpp_sys_2::GGML_TYPE_Q8_1,
+            KvCacheType::Q2_K => llama_cpp_sys_2::GGML_TYPE_Q2_K,
+            KvCacheType::Q3_K => llama_cpp_sys_2::GGML_TYPE_Q3_K,
+            KvCacheType::Q4_K => llama_cpp_sys_2::GGML_TYPE_Q4_K,
+            KvCacheType::Q5_K => llama_cpp_sys_2::GGML_TYPE_Q5_K,
+            KvCacheType::Q6_K => llama_cpp_sys_2::GGML_TYPE_Q6_K,
+            KvCacheType::Q8_K => llama_cpp_sys_2::GGML_TYPE_Q8_K,
+            KvCacheType::IQ2_XXS => llama_cpp_sys_2::GGML_TYPE_IQ2_XXS,
+            KvCacheType::IQ2_XS => llama_cpp_sys_2::GGML_TYPE_IQ2_XS,
+            KvCacheType::IQ3_XXS => llama_cpp_sys_2::GGML_TYPE_IQ3_XXS,
+            KvCacheType::IQ1_S => llama_cpp_sys_2::GGML_TYPE_IQ1_S,
+            KvCacheType::IQ4_NL => llama_cpp_sys_2::GGML_TYPE_IQ4_NL,
+            KvCacheType::IQ3_S => llama_cpp_sys_2::GGML_TYPE_IQ3_S,
+            KvCacheType::IQ2_S => llama_cpp_sys_2::GGML_TYPE_IQ2_S,
+            KvCacheType::IQ4_XS => llama_cpp_sys_2::GGML_TYPE_IQ4_XS,
+            KvCacheType::I8 => llama_cpp_sys_2::GGML_TYPE_I8,
+            KvCacheType::I16 => llama_cpp_sys_2::GGML_TYPE_I16,
+            KvCacheType::I32 => llama_cpp_sys_2::GGML_TYPE_I32,
+            KvCacheType::I64 => llama_cpp_sys_2::GGML_TYPE_I64,
+            KvCacheType::F64 => llama_cpp_sys_2::GGML_TYPE_F64,
+            KvCacheType::IQ1_M => llama_cpp_sys_2::GGML_TYPE_IQ1_M,
+            KvCacheType::BF16 => llama_cpp_sys_2::GGML_TYPE_BF16,
+            KvCacheType::TQ1_0 => llama_cpp_sys_2::GGML_TYPE_TQ1_0,
+            KvCacheType::TQ2_0 => llama_cpp_sys_2::GGML_TYPE_TQ2_0,
+            KvCacheType::MXFP4 => llama_cpp_sys_2::GGML_TYPE_MXFP4,
+        }
+    }
+}
+
+impl From<llama_cpp_sys_2::ggml_type> for KvCacheType {
+    fn from(value: llama_cpp_sys_2::ggml_type) -> Self {
+        match value {
+            x if x == llama_cpp_sys_2::GGML_TYPE_F32 => KvCacheType::F32,
+            x if x == llama_cpp_sys_2::GGML_TYPE_F16 => KvCacheType::F16,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q4_0 => KvCacheType::Q4_0,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q4_1 => KvCacheType::Q4_1,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q5_0 => KvCacheType::Q5_0,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q5_1 => KvCacheType::Q5_1,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q8_0 => KvCacheType::Q8_0,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q8_1 => KvCacheType::Q8_1,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q2_K => KvCacheType::Q2_K,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q3_K => KvCacheType::Q3_K,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q4_K => KvCacheType::Q4_K,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q5_K => KvCacheType::Q5_K,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q6_K => KvCacheType::Q6_K,
+            x if x == llama_cpp_sys_2::GGML_TYPE_Q8_K => KvCacheType::Q8_K,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ2_XXS => KvCacheType::IQ2_XXS,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ2_XS => KvCacheType::IQ2_XS,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ3_XXS => KvCacheType::IQ3_XXS,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ1_S => KvCacheType::IQ1_S,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ4_NL => KvCacheType::IQ4_NL,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ3_S => KvCacheType::IQ3_S,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ2_S => KvCacheType::IQ2_S,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ4_XS => KvCacheType::IQ4_XS,
+            x if x == llama_cpp_sys_2::GGML_TYPE_I8 => KvCacheType::I8,
+            x if x == llama_cpp_sys_2::GGML_TYPE_I16 => KvCacheType::I16,
+            x if x == llama_cpp_sys_2::GGML_TYPE_I32 => KvCacheType::I32,
+            x if x == llama_cpp_sys_2::GGML_TYPE_I64 => KvCacheType::I64,
+            x if x == llama_cpp_sys_2::GGML_TYPE_F64 => KvCacheType::F64,
+            x if x == llama_cpp_sys_2::GGML_TYPE_IQ1_M => KvCacheType::IQ1_M,
+            x if x == llama_cpp_sys_2::GGML_TYPE_BF16 => KvCacheType::BF16,
+            x if x == llama_cpp_sys_2::GGML_TYPE_TQ1_0 => KvCacheType::TQ1_0,
+            x if x == llama_cpp_sys_2::GGML_TYPE_TQ2_0 => KvCacheType::TQ2_0,
+            x if x == llama_cpp_sys_2::GGML_TYPE_MXFP4 => KvCacheType::MXFP4,
+            _ => KvCacheType::Unknown(value),
+        }
+    }
+}
+
 /// A safe wrapper around `llama_context_params`.
 ///
 /// Generally this should be created with [`Default::default()`] and then modified with `with_*` methods.
@@ -543,6 +667,62 @@ impl LlamaContextParams {
     #[must_use]
     pub fn swa_full(&self) -> bool {
         self.context_params.swa_full
+    }
+
+    /// Set the KV cache data type for K
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use llama_cpp_2::context::params::{LlamaContextParams, KvCacheType};
+    /// let params = LlamaContextParams::default().with_type_k(KvCacheType::Q4_0);
+    /// assert_eq!(params.type_k(), KvCacheType::Q4_0);
+    /// ```
+    #[must_use]
+    pub fn with_type_k(mut self, type_k: KvCacheType) -> Self {
+        self.context_params.type_k = type_k.into();
+        self
+    }
+
+    /// Get the KV cache data type for K
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let params = llama_cpp_2::context::params::LlamaContextParams::default();
+    /// let _ = params.type_k();
+    /// ```
+    #[must_use]
+    pub fn type_k(&self) -> KvCacheType {
+        KvCacheType::from(self.context_params.type_k)
+    }
+
+    /// Set the KV cache data type for V
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use llama_cpp_2::context::params::{LlamaContextParams, KvCacheType};
+    /// let params = LlamaContextParams::default().with_type_v(KvCacheType::Q4_1);
+    /// assert_eq!(params.type_v(), KvCacheType::Q4_1);
+    /// ```
+    #[must_use]
+    pub fn with_type_v(mut self, type_v: KvCacheType) -> Self {
+        self.context_params.type_v = type_v.into();
+        self
+    }
+
+    /// Get the KV cache data type for V
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let params = llama_cpp_2::context::params::LlamaContextParams::default();
+    /// let _ = params.type_v();
+    /// ```
+    #[must_use]
+    pub fn type_v(&self) -> KvCacheType {
+        KvCacheType::from(self.context_params.type_v)
     }
 }
 


### PR DESCRIPTION
## Add KV cache type (K/V) configuration to LlamaContextParams
### Motivation
Expose KV cache data types for K and V in the safe Rust API to match llama.cpp capabilities and allow users to tune memory/perf trade-offs without dropping to FFI.
### What’s in this PR
- Add KvCacheType enum covering all current ggml_type values:
- F32, F16, BF16, F64
- Q4_0, Q4_1, Q5_0, Q5_1, Q8_0, Q8_1
- Q2_K, Q3_K, Q4_K, Q5_K, Q6_K, Q8_K
- IQ1_S, IQ1_M, IQ2_XXS, IQ2_XS, IQ2_S, IQ3_XXS, IQ3_S, IQ4_NL, IQ4_XS
- I8, I16, I32, I64
- TQ1_0, TQ2_0, MXFP4
- Add Unknown(ggml_type) variant to preserve forward compatibility with new ggml types.
- Add fluent setters and getters on LlamaContextParams:
- with_type_k(KvCacheType) / type_k() -KvCacheType
- with_type_v(KvCacheType) / type_v() -KvCacheType
- Implement From<KvCacheTypefor ggml_type and From<ggml_typefor KvCacheType.

### Usage
```rust
use llama_cpp_2::context::params::{LlamaContextParams, KvCacheType};

// Configure K/V cache precision
let params = LlamaContextParams::default()
.with_type_k(KvCacheType::F16)
.with_type_v(KvCacheType::Q4_0);

// Inspect current types
match params.type_k() {
KvCacheType::Q4_0 ={ /* ... / }
KvCacheType::Unknown(raw) ={ /* handle forward-compat value / }
_ ={}
}
```

### Compatibility
- Backward-compatible: new API only; defaults unchanged (llama.cpp’s default F16 still applies if not overridden).
- Unknown(ggml_type) ensures code remains functional when ggml adds new types.

### Implementation notes
- Changes are localized to llama-cpp-2/src/context/params.rs.
- No changes to llama-cpp-sys-2; we rely on generated ggml_type constants.
