### PR TITLE
Multimodality improvements

### DIFF
--- a/examples/mtmd/src/mtmd.rs
+++ b/examples/mtmd/src/mtmd.rs
@@ -51,7 +51,7 @@ pub struct MtmdCliParams {
     #[arg(short = 't', long = "threads", value_name = "N", default_value = "4")]
     pub n_threads: i32,
     /// Number of tokens to process in a batch during eval chunks
-    #[arg(long = "batch-size", value_name = "b", default_value = "64")]
+    #[arg(long = "batch-size", value_name = "b", default_value = "1")]
     pub batch_size: i32,
     /// Maximum number of tokens in context
     #[arg(long = "n-tokens", value_name = "N", default_value = "4096")]

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -25,18 +25,18 @@ use crate::token::LlamaToken;
 /// let audio_chunk = MtmdInputChunkType::Audio;
 ///
 /// assert_eq!(text_chunk, MtmdInputChunkType::Text);
-/// assert_eq!(text_chunk as u32, llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_TEXT);
+/// assert_eq!(text_chunk, llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_TEXT.into());
 /// assert_ne!(text_chunk, image_chunk);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
 pub enum MtmdInputChunkType {
     /// Text input chunk
-    Text = llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_TEXT,
+    Text = llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_TEXT as _,
     /// Image input chunk
-    Image = llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_IMAGE,
+    Image = llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_IMAGE as _,
     /// Audio input chunk
-    Audio = llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_AUDIO,
+    Audio = llama_cpp_sys_2::MTMD_INPUT_CHUNK_TYPE_AUDIO as _,
 }
 
 impl From<llama_cpp_sys_2::mtmd_input_chunk_type> for MtmdInputChunkType {


### PR DESCRIPTION
Improves a few issues in the mtmd example and wrappers that remained from #790 :

* fixes the batch size param (thanks @haixuanTao for spotting this)
* addresses remaining nits from @MarcusDunn 
* clippy cleanup