### PR TITLE
feat(opencl): add optional OpenCL backend support via Cargo feature

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -32,6 +32,7 @@ sampler = []
 # Only has an impact on Android.
 android-shared-stdcxx = ["llama-cpp-sys-2/shared-stdcxx"]
 mtmd = ["llama-cpp-sys-2/mtmd"]
+opencl = ["llama-cpp-sys-2/opencl"]
 
 
 [target.'cfg(all(target_os = "macos", any(target_arch = "aarch64", target_arch = "arm64")))'.dependencies]

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -39,6 +39,7 @@ include = [
     "/llama.cpp/ggml/src/ggml-cuda/**/*",
     "/llama.cpp/ggml/src/ggml-metal/**/*",
     "/llama.cpp/ggml/src/ggml-vulkan/**/*",
+    "/llama.cpp/ggml/src/ggml-opencl/**/*",
 
     "/llama.cpp/ggml/src/llamafile/sgemm.h",
     "/llama.cpp/ggml/src/llamafile/sgemm.cpp",
@@ -81,3 +82,4 @@ openmp = []
 # Only has an impact on Android.
 shared-stdcxx = []
 mtmd = []
+opencl = []

--- a/llama-cpp-sys-2/README.md
+++ b/llama-cpp-sys-2/README.md
@@ -1,5 +1,5 @@
 # llama-cpp-sys
 
-Raw bindings to llama.cpp with cuda support.
+Raw bindings to llama.cpp with cuda and opencl support.
 
 See [llama-cpp-2](https://crates.io/crates/llama-cpp-2) for a safe API.

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -625,6 +625,27 @@ fn main() {
         }
     }
 
+    // OpenCL backend
+    if cfg!(feature = "opencl") {
+        config.define("GGML_OPENCL", "ON");
+        // Explicit for clarity; upstream defaults are ON
+        config.define("GGML_OPENCL_USE_ADRENO_KERNELS", "ON");
+        config.define("GGML_OPENCL_EMBED_KERNELS", "ON");
+
+        match target_os {
+            TargetOs::Apple(_) => {
+                println!("cargo:rustc-link-lib=framework=OpenCL");
+            }
+            TargetOs::Windows(_) => {
+                println!("cargo:rustc-link-lib=OpenCL");
+            }
+            TargetOs::Linux | TargetOs::Android => {
+                println!("cargo:rustc-link-lib=OpenCL");
+            }
+            _ => (),
+        }
+    }
+
     // Android doesn't have OpenMP support AFAICT and openmp is a default feature. Do this here
     // rather than modifying the defaults in Cargo.toml just in case someone enables the OpenMP feature
     // and tries to build for Android anyway.


### PR DESCRIPTION
Hey mate,

Simple yet high value add, I thought I should upstream it. I have tested this on Linux and Android. The OpenCL backend is much more reliable than Vulkan.

## ✨ Summary

- Introduce an `opencl` feature for both crates, package ggml-opencl sources, and enable GGML_OPENCL in build.rs with per-OS linking to the OpenCL loader. Keeps changes consistent with existing CUDA/Vulkan patterns.

## 🔎 Diagnosis

- Place behind rust feature flag to avoid breaking existing builds
- Grab defaults from llama.cpp upstream: https://github.com/ggml-org/llama.cpp/blob/master/docs/backend/OPENCL.md

## 🚀 Changes

- New feature flag on `llama-cpp-2/Cargo.toml` and added new globbing to `llama-cpp-sys-2/Cargo.toml`
- Little tweak to the llama-cpp-sys-2 `README.md` should help SEO if that matters anymore
- Most of the work in `llama-cpp-2-sys/build.rs` - matched the existing patterns

## ☁️ What you’ll need to do

- Just build with the `opencl` feature flag

## 🧪 Smoke test

```
cargo run -p llama-cpp-2 --example usage --features opencl -- ${PATH_TO_MODEL} --verbose 
```

## ✅ Acceptance

- If someone else can do a manual test that would be great. A Linux box with a dediated GPU would be strong validation. 
  - Note: It might be that the llama.cpp OpenCL backend is only supported for Android which I can report is working great.
- A Windows or Mac build just to confirm the rust link commands in `build.rs` are correct. 