### PR TITLE
fix: Discover MSVC include paths for Windows bindgen builds

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -420,6 +420,44 @@ fn main() {
         }
     }
 
+    // Fix bindgen header discovery on Windows MSVC
+    // Use cc crate to discover MSVC include paths by compiling a dummy file
+    if matches!(target_os, TargetOs::Windows(WindowsVariant::Msvc)) {
+        // Create a minimal dummy C file to extract compiler flags
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dummy_c = Path::new(&out_dir).join("dummy.c");
+        std::fs::write(&dummy_c, "int main() { return 0; }").unwrap();
+        
+        // Use cc crate to get compiler with proper environment setup
+        let mut build = cc::Build::new();
+        build.file(&dummy_c);
+        
+        // Get the actual compiler command cc would use
+        let compiler = build.try_get_compiler().unwrap();
+        
+        // Extract include paths by checking compiler's environment
+        // cc crate sets up MSVC environment internally
+        let env_include = compiler.env().iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("INCLUDE"))
+            .map(|(_, v)| v);
+            
+        if let Some(include_paths) = env_include {
+            for include_path in include_paths.to_string_lossy().split(';').filter(|s| !s.is_empty()) {
+                bindings_builder = bindings_builder
+                    .clang_arg("-isystem")
+                    .clang_arg(include_path);
+                debug_log!("Added MSVC include path: {}", include_path);
+            }
+        }
+        
+        // Add MSVC compatibility flags
+        bindings_builder = bindings_builder
+            .clang_arg(format!("--target={}", target_triple))
+            .clang_arg("-fms-compatibility")
+            .clang_arg("-fms-extensions");
+
+        debug_log!("Configured bindgen with MSVC toolchain for target: {}", target_triple);
+    }
     let bindings = bindings_builder
         .generate()
         .expect("Failed to generate bindings");


### PR DESCRIPTION
Fixes bindgen compilation error on Windows MSVC with GPU features: 'stdbool.h' file not found in ggml.h:207

Root cause: bindgen's libclang cannot find MSVC standard C headers (stdbool.h, stddef.h, etc.) without explicit -isystem paths.

Solution:
- Use cc::Build to discover MSVC environment and extract INCLUDE paths
- Pass each path via -isystem to bindgen's clang
- Add MSVC compatibility flags (--target, -fms-compatibility, -fms-extensions)

Pattern follows existing Android fix at lines 390-414.

Enables Windows MSVC builds with GPU backends (cuda/vulkan/opencl). Tested in production with shimmy v1.6.0 (295/295 tests passing).