### PR TITLE
feat: Cargo publish --workspace

### DIFF
--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -35,10 +35,8 @@ jobs:
         run: cargo fmt --check
       - name: Test
         run: cargo test --features sampler
-      - name: Dry-Run Publishing llama-cpp-sys-2 Crate
-        run: RUST_BACKTRACE=1 cargo publish --package llama-cpp-sys-2 --verbose --dry-run
-      - name: Dry-Run Publishing llama-cpp-2 Crate
-        run: RUST_BACKTRACE=1 cargo publish --package llama-cpp-2 --verbose --dry-run
+      - name: Dry-Run Publishing
+        run: RUST_BACKTRACE=1 cargo publish --workspace --verbose --dry-run
   arm64:
     name: Check that it builds on various targets
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-upon-release.yml
+++ b/.github/workflows/publish-upon-release.yml
@@ -18,10 +18,7 @@ jobs:
         with:
           submodules: recursive
       - name: Publish crates for llama-cpp-sys-2
-        run: RUST_BACKTRACE=1 cargo publish --package llama-cpp-sys-2 --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --verbose 
-      - name: Publish crates for llama-cpp-2
-        run: RUST_BACKTRACE=1 cargo publish --package llama-cpp-2 --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --verbose 
-        
+        run: RUST_BACKTRACE=1 cargo publish --workspace --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --verbose
       # Trigger the 'update-toml-version' workflow
       - name: Dispatch Update TOML Version Event
         if: success()  # Ensure this runs only if the previous steps were successful

--- a/examples/embeddings/Cargo.toml
+++ b/examples/embeddings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "embeddings"
 version = "0.1.123"
 edition = "2021"
+publish = false
 
 [dependencies]
 llama-cpp-2 = { path = "../../llama-cpp-2", version = "0.1.69" }

--- a/examples/mtmd/Cargo.toml
+++ b/examples/mtmd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mtmd"
 version = "0.1.86"
 edition = "2021"
+publish = false
 
 [dependencies]
 llama-cpp-2 = { path = "../../llama-cpp-2", version = "0.1.86", features = ["mtmd"] }

--- a/examples/reranker/Cargo.toml
+++ b/examples/reranker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reranker"
 version = "0.1.86"
 edition = "2021"
+publish = false
 
 [dependencies]
 llama-cpp-2 = { path = "../../llama-cpp-2", version = "0.1.86" }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simple"
 version = "0.1.123"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Rust 1.90.0 stabilised support for [workspace publishing](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#cargo-adds-native-support-for-workspace-publishing).

This eliminates the chicken-egg problem in the dry-run publishing stages if one requires a new version of llama-cpp-sys-2 as e.g. outlined in https://github.com/utilityai/llama-cpp-rs/pull/786#issuecomment-3130012902