### PR TITLE
Fixed build for linux+vulkan when not using system vulkan SDK

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -658,6 +658,11 @@ fn main() {
                 config.cxxflag("/FS");
             }
             TargetOs::Linux => {
+                // If we are not using system provided vulkan SDK, add vulkan libs for linking
+                if let Ok(vulkan_path) = env::var("VULKAN_SDK") {
+                    let vulkan_lib_path = Path::new(&vulkan_path).join("lib");
+                    println!("cargo:rustc-link-search={}", vulkan_lib_path.display());
+                }
                 println!("cargo:rustc-link-lib=vulkan");
             }
             _ => (),


### PR DESCRIPTION
On linux, the recommended way of using vulkan SDK is using their tarball, so more and more people will be using vulkan SDK which is not installed via their package manager. 

Added a check for env var VULKAN_SDK. If present, add the SDK's lib folder to link search path.