### PR TITLE
Refactor Token to String decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ version = "0.1.132"
 dependencies = [
  "anyhow",
  "clap",
+ "encoding_rs",
  "hf-hub",
  "llama-cpp-2",
 ]

--- a/examples/embeddings/Cargo.toml
+++ b/examples/embeddings/Cargo.toml
@@ -9,6 +9,7 @@ llama-cpp-2 = { path = "../../llama-cpp-2", version = "0.1.69" }
 hf-hub = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
+encoding_rs = { workspace = true }
 
 [features]
 cuda = ["llama-cpp-2/cuda"]

--- a/examples/embeddings/src/main.rs
+++ b/examples/embeddings/src/main.rs
@@ -134,11 +134,13 @@ fn main() -> Result<()> {
     // print the prompt token-by-token
     eprintln!();
 
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+
     for (i, token_line) in tokens_lines_list.iter().enumerate() {
         eprintln!("Prompt {i}");
         for token in token_line {
             // Attempt to convert token to string and print it; if it fails, print the token instead
-            match model.token_to_piece(*token, true, None) {
+            match model.token_to_piece(*token, &mut decoder, true, None) {
                 Ok(token_str) => eprintln!("{token} --> {token_str}"),
                 Err(e) => {
                     eprintln!("Failed to convert token to string, error: {e}");

--- a/examples/embeddings/src/main.rs
+++ b/examples/embeddings/src/main.rs
@@ -21,7 +21,7 @@ use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::LlamaModel;
-use llama_cpp_2::model::{AddBos, Special};
+use llama_cpp_2::model::{AddBos};
 
 #[derive(clap::Parser, Debug, Clone)]
 struct Args {
@@ -138,7 +138,7 @@ fn main() -> Result<()> {
         eprintln!("Prompt {i}");
         for token in token_line {
             // Attempt to convert token to string and print it; if it fails, print the token instead
-            match model.token_to_str(*token, Special::Tokenize) {
+            match model.token_to_piece(*token, true, None) {
                 Ok(token_str) => eprintln!("{token} --> {token_str}"),
                 Err(e) => {
                     eprintln!("Failed to convert token to string, error: {e}");

--- a/examples/mtmd/src/mtmd.rs
+++ b/examples/mtmd/src/mtmd.rs
@@ -201,7 +201,7 @@ impl<'a> MtmdCliContext<'a> {
             }
 
             // Print token
-            let piece = model.token_to_str(token, Special::Tokenize)?;
+            let piece = model.token_to_piece(token, true, None)?;
             print!("{piece}");
             io::stdout().flush()?;
 

--- a/examples/reranker/src/main.rs
+++ b/examples/reranker/src/main.rs
@@ -125,12 +125,14 @@ fn main() -> Result<()> {
     // print the prompt token-by-token
     eprintln!();
 
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+
     for (i, token_line) in tokens_lines_list.iter().enumerate() {
         eprintln!("Prompt {i} --> {}", prompt_lines[i]);
         eprintln!("Number of tokens: {}", token_line.len());
         for token in token_line {
             // Attempt to convert token to string and print it; if it fails, print the token instead
-            match model.token_to_piece(*token, true, None) {
+            match model.token_to_piece(*token, &mut decoder, true, None) {
                 Ok(token_str) => eprintln!("{token} --> {token_str}"),
                 Err(e) => {
                     eprintln!("Failed to convert token to string, error: {e}");

--- a/examples/reranker/src/main.rs
+++ b/examples/reranker/src/main.rs
@@ -20,7 +20,7 @@ use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::LlamaModel;
-use llama_cpp_2::model::{AddBos, Special};
+use llama_cpp_2::model::{AddBos};
 
 #[derive(clap::Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
@@ -130,7 +130,7 @@ fn main() -> Result<()> {
         eprintln!("Number of tokens: {}", token_line.len());
         for token in token_line {
             // Attempt to convert token to string and print it; if it fails, print the token instead
-            match model.token_to_str(*token, Special::Tokenize) {
+            match model.token_to_piece(*token, true, None) {
                 Ok(token_str) => eprintln!("{token} --> {token_str}"),
                 Err(e) => {
                     eprintln!("Failed to convert token to string, error: {e}");

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -289,8 +289,10 @@ either reduce n_len or increase n_ctx"
     // print the prompt token-by-token
     eprintln!();
 
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+
     for token in &tokens_list {
-        eprint!("{}", model.token_to_piece(*token, true, None)?);
+        eprint!("{}", model.token_to_piece(*token, &mut decoder, true, None)?);
     }
 
     std::io::stderr().flush()?;
@@ -321,6 +323,7 @@ either reduce n_len or increase n_ctx"
         LlamaSampler::greedy(),
     ]);
 
+
     while n_cur <= n_len {
         // sample the next token
         {
@@ -334,7 +337,7 @@ either reduce n_len or increase n_ctx"
                 break;
             }
 
-            let output_string = model.token_to_piece(token, true, None)?;
+            let output_string = model.token_to_piece(token, &mut decoder, true, None)?;
             // use `Decoder.decode_to_string()` to avoid the intermediate buffer
             print!("{output_string}");
             std::io::stdout().flush()?;

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -15,7 +15,7 @@ use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::kv_overrides::ParamOverrideValue;
 use llama_cpp_2::model::params::{LlamaModelParams, LlamaSplitMode};
 use llama_cpp_2::model::LlamaModel;
-use llama_cpp_2::model::{AddBos, Special};
+use llama_cpp_2::model::{AddBos};
 use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::{ggml_time_us, send_logs_to_tracing, LogOptions};
 
@@ -290,7 +290,7 @@ either reduce n_len or increase n_ctx"
     eprintln!();
 
     for token in &tokens_list {
-        eprint!("{}", model.token_to_str(*token, Special::Tokenize)?);
+        eprint!("{}", model.token_to_piece(*token, true, None)?);
     }
 
     std::io::stderr().flush()?;
@@ -316,9 +316,6 @@ either reduce n_len or increase n_ctx"
 
     let t_main_start = ggml_time_us();
 
-    // The `Decoder`
-    let mut decoder = encoding_rs::UTF_8.new_decoder();
-
     let mut sampler = LlamaSampler::chain_simple([
         LlamaSampler::dist(seed.unwrap_or(1234)),
         LlamaSampler::greedy(),
@@ -337,10 +334,8 @@ either reduce n_len or increase n_ctx"
                 break;
             }
 
-            let output_bytes = model.token_to_bytes(token, Special::Tokenize)?;
+            let output_string = model.token_to_piece(token, true, None)?;
             // use `Decoder.decode_to_string()` to avoid the intermediate buffer
-            let mut output_string = String::with_capacity(32);
-            let _decode_result = decoder.decode_to_string(&output_bytes, &mut output_string, false);
             print!("{output_string}");
             std::io::stdout().flush()?;
 

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -35,7 +35,7 @@ fn main() {
     let tokens_list = model
         .str_to_token(&prompt, AddBos::Always)
         .unwrap_or_else(|_| panic!("failed to tokenize {prompt}"));
-    let n_len = 64;
+    let n_len = 1024;
 
     // create a llama_batch with size 512
     // we use this object to submit token data for decoding
@@ -68,10 +68,8 @@ fn main() {
                 break;
             }
 
-            let output_bytes = model.token_to_bytes(token, Special::Tokenize).unwrap();
+            let output_string = model.token_to_piece(token, 1024, true, None).unwrap();
             // use `Decoder.decode_to_string()` to avoid the intermediate buffer
-            let mut output_string = String::with_capacity(32);
-            let _decode_result = decoder.decode_to_string(&output_bytes, &mut output_string, false);
             print!("{output_string}");
             std::io::stdout().flush().unwrap();
 

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -68,7 +68,7 @@ fn main() {
                 break;
             }
 
-            let output_string = model.token_to_piece(token, 1024, true, None).unwrap();
+            let output_string = model.token_to_piece(token, &mut decoder, true, None).unwrap();
             // use `Decoder.decode_to_string()` to avoid the intermediate buffer
             print!("{output_string}");
             std::io::stdout().flush().unwrap();

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -14,9 +14,9 @@ llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.132" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
+encoding_rs = { workspace = true }
 
 [dev-dependencies]
-encoding_rs = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]


### PR DESCRIPTION
As discussed in #856 and #826 decoding to tokens has some special logic that stands in the way of llama token generation as flexibly as required. Based on the inital proposed "quick" fix in #856 the proposed sensible solution is to refactor the decoding functions into a leaner interface that more closely mimics the actual llama.cpp structure and provides a type safe interface for rust to use.

This PR implements the proposed interface building on top of `llama_token_to_piece` two new public functions are introduced:
1. `model.token_to_piece_bytes -> [u8]` which just a thin wrapper around `llama_token_to_piece` with type conversion between rust <-> c. It returns raw bytes and places the burdon of handling errors and decoding the bytes on the caller
2. `model.token_to_piece -> String` which handles byte decoding to String, note that this requires using a `decoder` supplied to the function. See c93fac04e1a5a937981f849576fcf331e79e6975 for more details on the thought process

Legacy code that is now considered deprecated and will can be removed in the future:
- `enum Special`
- `fn token_to_str`
- `fn token_to_bytes`
- `fn tokens_to_str`
- `fn token_to_str_with_size`
- `fn token_to_bytes_with_size`

Also note that the `deprecated::since` version number will be need to be set to the version when the deprecation is merged. Additionally consider bumping to `0.2.0` might make sense.