### PR TITLE
Bundle CMakeLists.txt, to fix failing build with mtmd flag

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -31,6 +31,7 @@ include = [
     "/llama.cpp/src/models/*.cpp",
     "/llama.cpp/tools/mtmd/*.h",
     "/llama.cpp/tools/mtmd/*.cpp",
+    "/llama.cpp/tools/mtmd/CMakeLists.txt",
 
     "/llama.cpp/convert_hf_to_gguf.py", # Yes, it's required
     "/llama.cpp/common/build-info.cpp.in",


### PR DESCRIPTION
Currently, with `mtmd` flag the build fails, as the `tools/` folder is missing the `CMakeLists.txt`, because it is not included.
With this, the issue should be resolved.