### PR TITLE
fix: Makefile: No such file or directory ROCm error

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -46,6 +46,7 @@ include = [
     "/llama.cpp/ggml/src/ggml-cuda/**/*",
     "/llama.cpp/ggml/src/ggml-metal/**/*",
     "/llama.cpp/ggml/src/ggml-vulkan/**/*",
+    "/llama.cpp/ggml/src/ggml-hip/**/*",
 
     "/llama.cpp/ggml/src/llamafile/sgemm.h",
     "/llama.cpp/ggml/src/llamafile/sgemm.cpp",


### PR DESCRIPTION
I am so sorry, I forgot to add ggml-hip to the include list.
I've packaged it and tested it myself and I can guarantee it works now.

Sorry again for the trouble.