### PR TITLE
Bundle only MTMD tools

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -31,7 +31,8 @@ include = [
     "/llama.cpp/src/models/*.cpp",
     "/llama.cpp/tools/mtmd/*.h",
     "/llama.cpp/tools/mtmd/*.cpp",
-    "/llama.cpp/tools/mtmd/CMakeLists.txt",
+    "/llama.cpp/tools/mtmd/models/*.h",
+    "/llama.cpp/tools/mtmd/models/*.cpp",
 
     "/llama.cpp/convert_hf_to_gguf.py", # Yes, it's required
     "/llama.cpp/common/build-info.cpp.in",


### PR DESCRIPTION
This is a second attempt at fixing the mtmd build. Turns out the [previous PR](https://github.com/utilityai/llama-cpp-rs/pull/928) did still include more folders from `tools/` than it was necessary and we would need their own CMakeLists.txt being pulled for the build. This change circumvents that including just the `tools/mtmd` folder, which should be also faster.

I left the comments in, since I think they provide reasonable value why did this change occur.