### PR TITLE
Fix tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,21 +35,39 @@ git clone --recursive https://github.com/utilityai/llama-cpp-rs
 cd llama-cpp-rs
 ```
 
-Run the simple example (add `--features cuda` if you have a cuda gpu)
+Run the simple example (add the hardware dependent features like `--features cuda` or `--features vulkan` if you have a supported gpu)
 
 ```bash
 cargo run --release --bin simple -- --prompt "The way to kill a linux process is" hf-model TheBloke/Llama-2-7B-GGUF llama-2-7b.Q4_K_M.gguf
 ```
 
-Run the tools example (add `--features cuda` if you have a cuda gpu)
+Run the `tools` example (again, add `--features cuda` or `--features vulkan` if you have a supported gpu)
 
 ```bash
-cargo run --release --example tools -- hf-model TheBloke/Llama-2-7B-GGUF llama-2-7b.Q4_K_M.gguf
+cargo run --release --example tools -- hf-model unsloth/Qwen3.5-0.8B-GGUF Qwen3.5-0.8B-Q4_K_M.gguf
 ```
 
-The tool-calling path now exposes the raw llama.cpp bindings needed to pass tool JSON into chat templates, retrieve the generated grammar, and parse OpenAI-compatible JSON responses from Rust.
+This will use the `llama.cpp` bindings to pass tool JSON into the appropriate chat template provided in the model's metadata to produce a response that contains the syntax for a tool call:
+```
+<tool_call>
+<function=get_weather>
+<parameter=city>
+Paris
+</parameter>
+<parameter=unit>
+c
+</parameter>
+</function>
+</tool_call>
+```
 
-Run the OpenAI Style Completions Server (add `--features cuda` if you have a cuda gpu)
+The tool-calling path also exposes the `llama.cpp` bindings needed to retrieve the generated grammar, and parse responses in an OpenAI-compatible way from Rust. The `tools_reasoning` example illustrates this:
+
+```bash
+cargo run --release --example tools_reasoning -- --continuous hf-model unsloth/Qwen3.5-0.8B-GGUF Qwen3.5-0.8B-Q4_K_M.gguf
+```
+
+Run the OpenAI Style Completions Server (add `--features cuda` or so if you have a supported gpu)
 
 ```bash
 cargo run -p openai-server -- hf-model QuantFactory/Meta-Llama-3-8B-Instruct-GGUF Meta-Llama-3-8B-Instruct.Q8_0.gguf

--- a/examples/tools_reasoning.rs
+++ b/examples/tools_reasoning.rs
@@ -1,7 +1,7 @@
 //! Demonstrates tool calling with explicit reasoning parsing enabled.
 //!
 //! Usage:
-//!   cargo run --example tools_reasoning -- [--continous] hf-model unsloth/Qwen3.5-4B-GGUF Qwen3.5-4B-Q4_K_M.gguf
+//!   cargo run --example tools_reasoning -- [--continuous] hf-model unsloth/Qwen3.5-4B-GGUF Qwen3.5-4B-Q4_K_M.gguf
 use hf_hub::api::sync::ApiBuilder;
 use llama_cpp_2::context::params::LlamaContextParams;
 use llama_cpp_2::llama_backend::LlamaBackend;
@@ -24,7 +24,7 @@ fn resolve_args() -> Result<(PathBuf, bool), Box<dyn std::error::Error>> {
     let mut continuous = false;
     let mut positional = Vec::new();
     for arg in args {
-        if arg == "--continous" {
+        if arg == "--continuous" {
             continuous = true;
         } else {
             positional.push(arg);
@@ -34,7 +34,7 @@ fn resolve_args() -> Result<(PathBuf, bool), Box<dyn std::error::Error>> {
     let mut positional = positional.into_iter();
     let first = positional.next().ok_or_else(|| {
         format!(
-            "Usage: {exe} [--continous] <model_path> | {exe} [--continous] hf-model <repo> <model>"
+            "Usage: {exe} [--continuous] <model_path> | {exe} [--continuous] hf-model <repo> <model>"
         )
     })?;
 
@@ -296,7 +296,7 @@ fn assistant_tool_call_message(parsed_message: &serde_json::Value) -> serde_json
                         .and_then(|function| function.get("name"))
                         .cloned()
                         .unwrap_or(serde_json::Value::Null),
-                    "arguments": arguments.to_string(),
+                    "arguments": arguments,
                 }
             })
         })
@@ -311,6 +311,16 @@ fn assistant_tool_call_message(parsed_message: &serde_json::Value) -> serde_json
             .unwrap_or(serde_json::Value::Null),
         "tool_calls": tool_calls,
     })
+}
+
+fn unwrap_arguments(args: serde_json::Value) -> Option<serde_json::Value> {
+    // For some reason the tool calling API expects the parameters value not to be a JSON object,
+    // but a string serialization of a JSON object.
+    if let serde_json::Value::String(s) = args {
+	serde_json::from_str(&s).ok()
+    } else {
+	None
+    }
 }
 
 fn main() {
@@ -376,7 +386,7 @@ fn main() {
         .apply_chat_template_oaicompat(&template, &options)
         .expect("Failed to apply chat template");
 
-    let generated_text = generate_text(&model, &backend, &result, 128);
+    let generated_text = generate_text(&model, &backend, &result, 1024);
     let mut parsed_summaries = Vec::new();
 
     let parsed_json = result
@@ -400,7 +410,7 @@ fn main() {
             .unwrap_or_default();
 
         if tool_calls.is_empty() {
-            println!("\nNo tool calls were produced, skipping --continous follow-up.");
+            println!("\nNo tool calls were produced, skipping --continuous follow-up.");
         } else {
             let mut conversation = messages.as_array().cloned().expect("messages is an array");
             conversation.push(assistant_tool_call_message(&parsed_message));
@@ -420,6 +430,7 @@ fn main() {
                 let function_arguments = function
                     .get("arguments")
                     .cloned()
+                    .and_then(unwrap_arguments)
                     .unwrap_or(serde_json::Value::Null);
                 let tool_output = mock_tool_response(function_name, &function_arguments);
                 println!(
@@ -457,7 +468,7 @@ fn main() {
             let follow_up_result = model
                 .apply_chat_template_oaicompat(&template, &follow_up_options)
                 .expect("Failed to apply follow-up chat template");
-            let follow_up_text = generate_text(&model, &backend, &follow_up_result, 192);
+            let follow_up_text = generate_text(&model, &backend, &follow_up_result, 1024);
 
             let follow_up_raw = follow_up_result
                 .parse_response_oaicompat(&follow_up_text, false)

--- a/examples/tools_reasoning.rs
+++ b/examples/tools_reasoning.rs
@@ -308,7 +308,7 @@ fn assistant_tool_call_message(parsed_message: &serde_json::Value) -> serde_json
         "reasoning_content": parsed_message
             .get("reasoning_content")
             .cloned()
-            .unwrap_or(serde_json::Value::Null),
+            .unwrap_or(json!("")),
         "tool_calls": tool_calls,
     })
 }


### PR DESCRIPTION
This fixes the tool calling examples and changes the readme to match.

Funnily enough, the smallest model I tested with, unsloth's `Qwen3.5-0.8B-Q4_K_M.gguf` was the only one that noticed that is was talking to a broken weather service:
```
 {
  "content": "I've retrieved the weather information for Paris. Here's the summary:\n\n**Current Weather in Paris:**\n- **Condition:** Sunny\n- **Temperature:** 18°C (64.4°F)\n- **Wind:** Light wind\n\nThis is a mock response from the weather service. Please note that this is not real weather data for Paris. If you need real weather information, I recommend checking official weather services or using a reliable weather app.",
  "reasoning_content": "The function returned a mock weather response for \"Paris\" with the city name \"Paris\" and unit \"c\" (Celsius). The response shows:\n- Mock weather for Unknown City: sunny, 18 C, light wind.\n\nThis seems like a mock response that doesn't actually have real weather data for Paris. I should inform the user that this is a mock response and provide the information they received.\n",
  "role": "assistant"
}
```