### PR TITLE
Update to latest version

### DIFF
--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -190,7 +190,9 @@ impl MtmdContext {
     /// Check whether non-causal attention mask is needed before `llama_decode`.
     #[must_use]
     pub fn decode_use_non_causal(&self) -> bool {
-        unsafe { llama_cpp_sys_2::mtmd_decode_use_non_causal(self.context.as_ptr(), std::ptr::null()) }
+        unsafe {
+            llama_cpp_sys_2::mtmd_decode_use_non_causal(self.context.as_ptr(), std::ptr::null())
+        }
     }
 
     /// Check whether the current model uses M-RoPE for `llama_decode`.

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -190,7 +190,7 @@ impl MtmdContext {
     /// Check whether non-causal attention mask is needed before `llama_decode`.
     #[must_use]
     pub fn decode_use_non_causal(&self) -> bool {
-        unsafe { llama_cpp_sys_2::mtmd_decode_use_non_causal(self.context.as_ptr()) }
+        unsafe { llama_cpp_sys_2::mtmd_decode_use_non_causal(self.context.as_ptr(), std::ptr::null()) }
     }
 
     /// Check whether the current model uses M-RoPE for `llama_decode`.


### PR DESCRIPTION
Updated llama.cpp to `b8783`, so we can get the gemma4 audio support in 🎉 .
Related to that, there was a breaking change with `mtmd_decode_use_non_causal`, which now accepts a chunk parameter.
I have so far just instantiated to `null`, which should be okay, as it exactly mirrors the previous functionality.
