### PR TITLE
feat: add fit_params for automatic GPU/CPU layer splitting

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -86,6 +86,9 @@ pub enum LlamaCppError {
     /// Failed to convert JSON schema to grammar.
     #[error("JsonSchemaToGrammarError: {0}")]
     JsonSchemaToGrammarError(String),
+    /// There was an error fitting model parameters to available memory.
+    #[error("{0}")]
+    FitError(#[from] crate::model::params::FitError),
 }
 
 /// There was an error while getting the chat template from a model.

--- a/llama-cpp-2/src/model/params.rs
+++ b/llama-cpp-2/src/model/params.rs
@@ -1,5 +1,6 @@
 //! A safe wrapper around `llama_model_params`.
 
+use crate::context::params::LlamaContextParams;
 use crate::model::params::kv_overrides::KvOverrides;
 use crate::LlamaCppError;
 use std::ffi::{c_char, CStr};
@@ -8,6 +9,24 @@ use std::pin::Pin;
 use std::ptr::null;
 
 pub mod kv_overrides;
+
+/// Result of [`LlamaModelParams::fit_params`], containing the fitted context size.
+#[derive(Debug, Clone)]
+pub struct FitResult {
+    /// The context size after fitting (may have been reduced from the requested value).
+    pub n_ctx: u32,
+}
+
+/// Error returned by [`LlamaModelParams::fit_params`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum FitError {
+    /// Could not find allocations that are projected to fit available memory.
+    #[error("could not find allocations that fit available memory")]
+    Failure,
+    /// A hard error occurred during fitting (e.g. model not found at the specified path).
+    #[error("hard error during parameter fitting")]
+    Error,
+}
 
 #[allow(clippy::cast_possible_wrap)]
 #[allow(clippy::cast_possible_truncation)]
@@ -128,6 +147,7 @@ pub struct LlamaModelParams {
     kv_overrides: Vec<llama_cpp_sys_2::llama_model_kv_override>,
     buft_overrides: Vec<llama_cpp_sys_2::llama_model_tensor_buft_override>,
     devices: Pin<Box<[llama_cpp_sys_2::ggml_backend_dev_t; LLAMA_CPP_MAX_DEVICES]>>,
+    tensor_split: Vec<f32>,
 }
 
 impl Debug for LlamaModelParams {
@@ -263,6 +283,101 @@ impl LlamaModelParams {
 
         // set the pointer to the (potentially) new vector
         self.params.tensor_buft_overrides = self.buft_overrides.as_ptr();
+    }
+}
+
+impl LlamaModelParams {
+    /// Automatically fit model parameters to available device memory.
+    ///
+    /// Wraps llama.cpp's `llama_params_fit`, which determines optimal `n_gpu_layers`,
+    /// `tensor_split`, and `tensor_buft_overrides` based on available VRAM. On success
+    /// the model and context params are updated in place.
+    ///
+    /// # Requirements
+    ///
+    /// Per the C API docstring, only parameters that still hold their default value
+    /// are modified. In practice this means:
+    /// - `n_gpu_layers` must be at its default (`-1`). Do not call
+    ///   [`with_n_gpu_layers`](Self::with_n_gpu_layers) before this.
+    /// - No `tensor_buft_overrides` may be set. Do not call
+    ///   [`add_cpu_buft_override`](Self::add_cpu_buft_override) or
+    ///   [`add_cpu_moe_override`](Self::add_cpu_moe_override) before this.
+    /// - `cparams.n_ctx` is only auto-selected if it is `0`; otherwise it is left alone.
+    ///
+    /// # Arguments
+    ///
+    /// - `model_path` — path to the GGUF model file.
+    /// - `cparams` — context parameters; `n_ctx` may be modified (see above).
+    /// - `margins` — memory margin per device in bytes. Must have at least
+    ///   `llama_max_devices()` elements.
+    /// - `n_ctx_min` — minimum context size to preserve when reducing memory usage.
+    /// - `log_level` — minimum log level for fitting output; lower levels are routed
+    ///   to the debug log.
+    ///
+    /// # Thread safety
+    ///
+    /// This function is **not** thread safe: the underlying C call mutates the global
+    /// llama logger state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FitError::Failure`] if no fitting allocation could be found, or
+    /// [`FitError::Error`] on a hard error (e.g. the model file could not be read).
+    pub fn fit_params(
+        mut self: Pin<&mut Self>,
+        model_path: &CStr,
+        cparams: &mut LlamaContextParams,
+        margins: &mut [usize],
+        n_ctx_min: u32,
+        log_level: llama_cpp_sys_2::ggml_log_level,
+    ) -> Result<FitResult, FitError> {
+        let max_devices = unsafe { llama_cpp_sys_2::llama_max_devices() };
+        let max_buft = unsafe { llama_cpp_sys_2::llama_max_tensor_buft_overrides() };
+
+        // Allocate tensor_split output buffer.
+        self.tensor_split.clear();
+        self.tensor_split.resize(max_devices, 0.0);
+
+        // Reset and resize buft_overrides for fit output (null-terminated).
+        self.buft_overrides.clear();
+        self.buft_overrides.resize(
+            max_buft + 1,
+            llama_cpp_sys_2::llama_model_tensor_buft_override {
+                pattern: std::ptr::null(),
+                buft: std::ptr::null_mut(),
+            },
+        );
+
+        // Clear pointers before the call — fit writes directly into the buffers above.
+        self.params.tensor_split = null::<f32>();
+        self.params.tensor_buft_overrides = null();
+
+        let status = unsafe {
+            llama_cpp_sys_2::llama_params_fit(
+                model_path.as_ptr(),
+                &raw mut self.params,
+                &raw mut cparams.context_params,
+                self.tensor_split.as_mut_ptr(),
+                self.buft_overrides.as_mut_ptr(),
+                margins.as_mut_ptr(),
+                n_ctx_min,
+                log_level,
+            )
+        };
+
+        match status {
+            llama_cpp_sys_2::LLAMA_PARAMS_FIT_STATUS_SUCCESS => {}
+            llama_cpp_sys_2::LLAMA_PARAMS_FIT_STATUS_FAILURE => return Err(FitError::Failure),
+            _ => return Err(FitError::Error),
+        }
+
+        // Wire the owned buffers into the raw params.
+        self.params.tensor_split = self.tensor_split.as_ptr();
+        self.params.tensor_buft_overrides = self.buft_overrides.as_ptr();
+
+        Ok(FitResult {
+            n_ctx: cparams.context_params.n_ctx,
+        })
     }
 }
 
@@ -471,6 +586,7 @@ impl Default for LlamaModelParams {
                 buft: std::ptr::null_mut(),
             }],
             devices: Box::pin([std::ptr::null_mut(); 16]),
+            tensor_split: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Hi there, thanks for this great library.

I have been using it in another library and wanted the same feature as when llama-server is called with --fit. It is compiling and running with vulkan on linux and windows on my side and I used large Qwen3.5/3.6 and Gemma 4 models with this on limited vram (3070ti 8Gb).
I hope to get this merged so I can open source my library and get it published on crates.io

AI Disclaimer: Of course this code is generated but it is only a small change and I am already actively using this feature. Although it introduces a breaking change in the LlamaModelParams struct by adding the tensor_split.

## Summary

Wraps llama.cpp's [`llama_params_fit`](https://github.com/ggml-org/llama.cpp/blob/master/include/llama.h) C API as a safe method on `LlamaModelParams`. Given a model path, per-device memory margins, and a minimum context size, it fills in `n_gpu_layers`, `tensor_split`, and `tensor_buft_overrides` so the model fits available VRAM — and will reduce `cparams.n_ctx` if needed.

```rust
let mut mparams = Box::pin(LlamaModelParams::default());
let mut cparams = LlamaContextParams::default();
let mut margins = vec![0usize; unsafe { llama_cpp_sys_2::llama_max_devices() }];

let fit = mparams
    .as_mut()
    .fit_params(
        c"/path/to/model.gguf",
        &mut cparams,
        &mut margins,
        /* n_ctx_min */ 2048,
        llama_cpp_sys_2::GGML_LOG_LEVEL_INFO,
    )?;
```

## API shape

- Takes `&mut LlamaContextParams` (the safe wrapper), not the raw sys type, matching the convention in the rest of the crate.
- Takes `log_level: llama_cpp_sys_2::ggml_log_level` directly — the crate already uses this bindgen-generated type in `log.rs` and `llama_backend.rs` with no platform branching.
- `FitError` derives `thiserror::Error` and is wired into `LlamaCppError` via `#[from]`, matching `DecodeError`, `EncodeError`, `ChatTemplateError`, etc.
- `llama_params_fit` is documented as **not thread safe** (it mutates the global llama logger); this is called out in the rustdoc.

## Compatibility

The required C symbols (`llama_params_fit`, `llama_max_tensor_buft_overrides`, `LLAMA_PARAMS_FIT_STATUS_*`) are already present in the pinned llama.cpp submodule and covered by `llama-cpp-sys-2`'s bindgen allowlist (`allowlist_function("llama_.*")`). No submodule bump needed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy` (no new warnings in the added code)
- [x] `cargo test --features sampler` (81 pass, 0 fail)
- [x] `cargo publish --workspace --dry-run`
- [ ] CI (cross-platform build on Linux x86_64/arm64, macOS, Windows)
- [x] Smoke test against a real GGUF locally (requires model, outside CI) -- tested with large moe and dense qwen and gemma models

🤖 Generated with [Claude Code](https://claude.com/claude-code)