### PR TITLE
Add `common` feature flag to allow slimmer builds

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -25,7 +25,13 @@ serde_json = "1.0"
 tracing-subscriber = { workspace = true }
 
 [features]
-default = ["openmp", "android-shared-stdcxx"]
+default = ["openmp", "android-shared-stdcxx", "common"]
+# Enable the OpenAI-compatible / chat-template / JSON-schema-to-grammar APIs.
+# These are backed by `llama.cpp`'s `common/` static library; disabling drops
+# `libcommon.a` (~14 MB) plus the `wrapper_common.cpp` / `wrapper_oai.cpp`
+# bindings (~10 MB combined) from the link line. Enabled by default for
+# backwards compatibility.
+common = ["llama-cpp-sys-2/common"]
 cuda = ["llama-cpp-sys-2/cuda"]
 cuda-no-vmm = ["cuda", "llama-cpp-sys-2/cuda-no-vmm"]
 metal = ["llama-cpp-sys-2/metal"]
@@ -61,14 +67,17 @@ path = "../examples/usage.rs"
 [[example]]
 name = "tools"
 path = "../examples/tools.rs"
+required-features = ["common"]
 
 [[example]]
 name = "tools_reasoning"
 path = "../examples/tools_reasoning.rs"
+required-features = ["common"]
 
 [[example]]
 name = "openai_stream"
 path = "../examples/openai_stream.rs"
+required-features = ["common"]
 
 [[example]]
 name = "llguidance"

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -33,6 +33,7 @@ mod log;
 pub mod model;
 #[cfg(feature = "mtmd")]
 pub mod mtmd;
+#[cfg(feature = "common")]
 pub mod openai;
 pub mod sampling;
 pub mod timing;
@@ -41,6 +42,7 @@ pub mod token_type;
 
 pub use crate::context::session::LlamaStateSeqFlags;
 
+#[cfg(feature = "common")]
 pub(crate) fn status_is_ok(status: llama_cpp_sys_2::llama_rs_status) -> bool {
     status == llama_cpp_sys_2::LLAMA_RS_STATUS_OK
 }
@@ -84,6 +86,7 @@ pub enum LlamaCppError {
     #[error("Max devices exceeded. Max devices is {0}")]
     MaxDevicesExceeded(usize),
     /// Failed to convert JSON schema to grammar.
+    #[cfg(feature = "common")]
     #[error("JsonSchemaToGrammarError: {0}")]
     JsonSchemaToGrammarError(String),
 }
@@ -304,6 +307,7 @@ pub fn mlock_supported() -> bool {
 }
 
 /// Convert a JSON schema string into a llama.cpp grammar string.
+#[cfg(feature = "common")]
 pub fn json_schema_to_grammar(schema_json: &str) -> Result<String> {
     let schema_cstr = CString::new(schema_json)
         .map_err(|err| LlamaCppError::JsonSchemaToGrammarError(err.to_string()))?;
@@ -329,7 +333,7 @@ pub fn json_schema_to_grammar(schema_json: &str) -> Result<String> {
     result
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "common"))]
 mod tests {
     use super::json_schema_to_grammar;
 
@@ -401,11 +405,13 @@ pub enum ApplyChatTemplateError {
     #[error("ffi error {0}")]
     FfiError(i32),
     /// invalid grammar trigger data returned by llama.cpp.
+    #[cfg(feature = "common")]
     #[error("invalid grammar trigger data")]
     InvalidGrammarTriggerType,
 }
 
 /// Failed to parse a chat response.
+#[cfg(feature = "common")]
 #[derive(Debug, thiserror::Error)]
 pub enum ChatParseError {
     /// the string contained a null byte and thus could not be converted to a c string.

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -11,13 +11,16 @@ use crate::context::params::LlamaContextParams;
 use crate::context::LlamaContext;
 use crate::llama_backend::LlamaBackend;
 use crate::model::params::LlamaModelParams;
+#[cfg(feature = "common")]
 use crate::openai::{ChatParseStateOaicompat, OpenAIChatTemplateParams};
 use crate::token::LlamaToken;
 use crate::token_type::{LlamaTokenAttr, LlamaTokenAttrs};
+#[cfg(feature = "common")]
+use crate::{status_is_ok, ChatParseError};
 use crate::{
-    status_is_ok, ApplyChatTemplateError, ChatParseError, ChatTemplateError, LlamaContextLoadError,
-    LlamaLoraAdapterInitError, LlamaModelLoadError, MetaValError, NewLlamaChatMessageError,
-    StringToTokenError, TokenToStringError,
+    ApplyChatTemplateError, ChatTemplateError, LlamaContextLoadError, LlamaLoraAdapterInitError,
+    LlamaModelLoadError, MetaValError, NewLlamaChatMessageError, StringToTokenError,
+    TokenToStringError,
 };
 
 pub mod params;
@@ -95,6 +98,7 @@ impl LlamaChatMessage {
 }
 
 /// Grammar trigger kinds used for lazy grammar sampling.
+#[cfg(feature = "common")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GrammarTriggerType {
     /// Trigger on a specific token.
@@ -108,6 +112,7 @@ pub enum GrammarTriggerType {
 }
 
 /// Lazy grammar trigger from chat template generation.
+#[cfg(feature = "common")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GrammarTrigger {
     /// Trigger kind.
@@ -119,6 +124,7 @@ pub struct GrammarTrigger {
 }
 
 /// Result of applying a chat template with tool grammar support.
+#[cfg(feature = "common")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatTemplateResult {
     /// Rendered chat prompt.
@@ -945,6 +951,7 @@ impl LlamaModel {
     /// Apply the models chat template to some messages and return an optional tool grammar.
     /// `tools_json` should be an OpenAI-compatible tool definition JSON array string.
     /// `json_schema` should be a JSON schema string.
+    #[cfg(feature = "common")]
     #[tracing::instrument(skip_all)]
     pub fn apply_chat_template_with_tools_oaicompat(
         &self,
@@ -1135,6 +1142,7 @@ impl LlamaModel {
     }
 
     /// Apply the model chat template using OpenAI-compatible JSON messages.
+    #[cfg(feature = "common")]
     #[tracing::instrument(skip_all)]
     pub fn apply_chat_template_oaicompat(
         &self,
@@ -1340,6 +1348,7 @@ impl LlamaModel {
     }
 }
 
+#[cfg(feature = "common")]
 impl ChatTemplateResult {
     /// Parse a generated response into an OpenAI-compatible message JSON string.
     pub fn parse_response_oaicompat(

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -6,11 +6,11 @@ use std::fmt::{Debug, Formatter};
 
 use crate::context::LlamaContext;
 use crate::model::LlamaModel;
+#[cfg(feature = "common")]
+use crate::status_is_ok;
 use crate::token::data_array::LlamaTokenDataArray;
 use crate::token::logit_bias::LlamaLogitBias;
 use crate::token::LlamaToken;
-#[cfg(feature = "common")]
-use crate::status_is_ok;
 use crate::{GrammarError, SamplerAcceptError};
 
 /// A safe wrapper around `llama_sampler`.

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -9,7 +9,9 @@ use crate::model::LlamaModel;
 use crate::token::data_array::LlamaTokenDataArray;
 use crate::token::logit_bias::LlamaLogitBias;
 use crate::token::LlamaToken;
-use crate::{status_is_ok, GrammarError, SamplerAcceptError};
+#[cfg(feature = "common")]
+use crate::status_is_ok;
+use crate::{GrammarError, SamplerAcceptError};
 
 /// A safe wrapper around `llama_sampler`.
 pub struct LlamaSampler {
@@ -41,14 +43,21 @@ impl LlamaSampler {
     /// Accepts a token from the sampler, possibly updating the internal state of certain samplers
     /// (e.g. grammar, repetition, etc.)
     pub fn accept(&mut self, token: LlamaToken) {
-        let _ = self.try_accept(token);
+        #[cfg(feature = "common")]
+        {
+            let _ = self.try_accept(token);
+        }
+        #[cfg(not(feature = "common"))]
+        unsafe {
+            llama_cpp_sys_2::llama_sampler_accept(self.sampler, token.0);
+        }
     }
 
     /// Accepts several tokens from the sampler or context, possibly updating the internal state of
     /// certain samplers (e.g. grammar, repetition, etc.)
     pub fn accept_many(&mut self, tokens: impl IntoIterator<Item = impl Borrow<LlamaToken>>) {
         for token in tokens {
-            let _ = self.try_accept(*token.borrow());
+            self.accept(*token.borrow());
         }
     }
 
@@ -64,6 +73,7 @@ impl LlamaSampler {
     }
 
     /// Try accepting a token from the sampler. Returns an error if the sampler throws.
+    #[cfg(feature = "common")]
     pub fn try_accept(&mut self, token: LlamaToken) -> Result<(), SamplerAcceptError> {
         let sampler_result =
             unsafe { llama_cpp_sys_2::llama_rs_sampler_accept(self.sampler, token.0) };
@@ -286,6 +296,7 @@ impl LlamaSampler {
     }
 
     /// Grammar sampler
+    #[cfg(feature = "common")]
     #[must_use]
     pub fn grammar(
         model: &LlamaModel,
@@ -313,6 +324,7 @@ impl LlamaSampler {
     /// Lazy grammar sampler, introduced in <https://github.com/ggerganov/llama.cpp/pull/9639>
     ///
     /// This sampler enforces grammar rules only when specific trigger words or tokens are encountered.
+    #[cfg(feature = "common")]
     #[must_use]
     pub fn grammar_lazy(
         model: &LlamaModel,
@@ -352,6 +364,7 @@ impl LlamaSampler {
     /// Trigger patterns are regular expressions matched from the start of the
     /// generation output. The grammar sampler will be fed content starting from
     /// the first match group.
+    #[cfg(feature = "common")]
     #[must_use]
     pub fn grammar_lazy_patterns(
         model: &LlamaModel,

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -82,6 +82,14 @@ glob = "0.3.3"
 walkdir = "2"
 
 [features]
+default = ["common"]
+# Build the high-level OpenAI-compatible / chat-template / JSON-schema-to-grammar
+# helpers backed by llama.cpp's `common/` static library. Disabling this drops
+# `libcommon.a` (~14 MB) and the `wrapper_common.cpp` / `wrapper_oai.cpp`
+# bindings (~10 MB combined static archive) from the link line, which matters
+# for size-constrained downstream binaries that only need the core inference
+# API. Enabled by default to preserve backwards compatibility.
+common = []
 cuda = []
 # Disables the need to dynamically link against libcuda.so / cuda.dll
 cuda-no-vmm = ["cuda"]

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -278,9 +278,17 @@ fn main() {
         .allowlist_type("gguf_.*")
         .allowlist_function("llama_.*")
         .allowlist_type("llama_.*")
-        .allowlist_function("llama_rs_.*")
-        .allowlist_type("llama_rs_.*")
         .prepend_enum_name(false);
+
+    // The `llama_rs_*` symbols are emitted by `wrapper_common.cpp` /
+    // `wrapper_oai.cpp`, which are only compiled (and only have their headers
+    // included from `wrapper.h`) when the `common` feature is enabled.
+    if cfg!(feature = "common") {
+        bindings_builder = bindings_builder
+            .clang_arg("-DLLAMA_RS_BUILD_COMMON")
+            .allowlist_function("llama_rs_.*")
+            .allowlist_type("llama_rs_.*");
+    }
 
     // Configure mtmd feature if enabled
     if cfg!(feature = "mtmd") {
@@ -496,30 +504,32 @@ fn main() {
 
     debug_log!("Bindings Created");
 
-    let mut common_wrapper_build = cc::Build::new();
-    common_wrapper_build
-        .cpp(true)
-        .file("wrapper_common.cpp")
-        .file("wrapper_oai.cpp")
-        .include(&llama_src)
-        .include(llama_src.join("common"))
-        .include(llama_src.join("include"))
-        .include(llama_src.join("ggml/include"))
-        .include(llama_src.join("vendor"))
-        .flag_if_supported("-std=c++17")
-        .pic(true);
+    if cfg!(feature = "common") {
+        let mut common_wrapper_build = cc::Build::new();
+        common_wrapper_build
+            .cpp(true)
+            .file("wrapper_common.cpp")
+            .file("wrapper_oai.cpp")
+            .include(&llama_src)
+            .include(llama_src.join("common"))
+            .include(llama_src.join("include"))
+            .include(llama_src.join("ggml/include"))
+            .include(llama_src.join("vendor"))
+            .flag_if_supported("-std=c++17")
+            .pic(true);
 
-    if matches!(target_os, TargetOs::Windows(WindowsVariant::Msvc)) {
-        common_wrapper_build.flag("/std:c++17");
+        if matches!(target_os, TargetOs::Windows(WindowsVariant::Msvc)) {
+            common_wrapper_build.flag("/std:c++17");
+        }
+
+        // When static-stdcxx is enabled on Android, suppress the cc crate's automatic
+        // C++ stdlib linking (which defaults to c++_shared) so we can link c++_static instead.
+        if matches!(target_os, TargetOs::Android) && cfg!(feature = "static-stdcxx") {
+            common_wrapper_build.cpp_link_stdlib(None);
+        }
+
+        common_wrapper_build.compile("llama_cpp_sys_2_common_wrapper");
     }
-
-    // When static-stdcxx is enabled on Android, suppress the cc crate's automatic
-    // C++ stdlib linking (which defaults to c++_shared) so we can link c++_static instead.
-    if matches!(target_os, TargetOs::Android) && cfg!(feature = "static-stdcxx") {
-        common_wrapper_build.cpp_link_stdlib(None);
-    }
-
-    common_wrapper_build.compile("llama_cpp_sys_2_common_wrapper");
 
     // Build with Cmake
 
@@ -532,7 +542,10 @@ fn main() {
     config.define("LLAMA_BUILD_EXAMPLES", "OFF");
     config.define("LLAMA_BUILD_SERVER", "OFF");
     config.define("LLAMA_BUILD_TOOLS", "OFF");
-    config.define("LLAMA_BUILD_COMMON", "ON");
+    config.define(
+        "LLAMA_BUILD_COMMON",
+        if cfg!(feature = "common") { "ON" } else { "OFF" },
+    );
     config.define("LLAMA_CURL", "OFF");
 
     // Pass CMAKE_ environment variables down to CMake
@@ -999,7 +1012,7 @@ fn main() {
     assert_ne!(llama_libs.len(), 0);
 
     let common_lib_dir = out_dir.join("build").join("common");
-    if common_lib_dir.is_dir() {
+    if cfg!(feature = "common") && common_lib_dir.is_dir() {
         println!(
             "cargo:rustc-link-search=native={}",
             common_lib_dir.display()

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -544,7 +544,11 @@ fn main() {
     config.define("LLAMA_BUILD_TOOLS", "OFF");
     config.define(
         "LLAMA_BUILD_COMMON",
-        if cfg!(feature = "common") { "ON" } else { "OFF" },
+        if cfg!(feature = "common") {
+            "ON"
+        } else {
+            "OFF"
+        },
     );
     config.define("LLAMA_CURL", "OFF");
 

--- a/llama-cpp-sys-2/wrapper.h
+++ b/llama-cpp-sys-2/wrapper.h
@@ -1,4 +1,7 @@
 #include "llama.cpp/include/llama.h"
 #include "llama.cpp/ggml/include/gguf.h"
+
+#ifdef LLAMA_RS_BUILD_COMMON
 #include "wrapper_common.h"
 #include "wrapper_oai.h"
+#endif


### PR DESCRIPTION
This PR introduces a new `common` feature flag to help downstream users who need to strictly constrain their binary sizes. 

By default, common is enabled, meaning existing users won't see any changes - the default Cargo build is byte-for-byte equivalent to how it was before.

### Why this matters:
If a user only needs the core inference API, they can now opt out of common. Doing so drops about ~24 MB of static archives from the link line (specifically libcommon.a at ~14 MB, the wrapper archive at ~10 MB, and their associated objects). 

### What gets disabled when common is off?

*    The OpenAI-compatible chat-template helpers
*    The JSON-schema-to-grammar converter
*    Lazy-grammar samplers
*    The streaming OAI parser

### Implementation details:

*    LlamaSampler::accept now gracefully falls back to llama.cpp's core llama_sampler_accept when the feature is off, so the basic sampling loop still works perfectly without the status-returning wrapper.
*    Examples relying on the OAI APIs (tools, tools_reasoning, openai_stream) now have required-features = ["common"], so Cargo will automatically skip them if you're doing a slim build.

Users who want the slim build can now just opt-in like this:
```
    llama-cpp-2 = { version = "0.1", default-features = false, features = [...] }
```

### Shameless plug?! 😄 
I am using this to make my project [fono](https://github.com/bogdanr/fono) compact and self contained.