### PR TITLE
fix(cuda): disable NCCL autodetection by default + sync llama.cpp MTP wrappers/examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mtp-compare"
+version = "0.1.147"
+dependencies = [
+ "anyhow",
+ "clap",
+ "encoding_rs",
+ "hf-hub",
+ "llama-cpp-2",
+]
+
+[[package]]
 name = "mtp-example"
 version = "0.1.147"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mtp-example"
+version = "0.1.147"
+dependencies = [
+ "anyhow",
+ "clap",
+ "encoding_rs",
+ "hf-hub",
+ "llama-cpp-2",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "llama-cpp-2",
   "examples/embeddings",
   "examples/mtp",
+  "examples/mtp-compare",
   "examples/simple",
   "examples/reranker",
   "examples/mtmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "llama-cpp-sys-2",
   "llama-cpp-2",
   "examples/embeddings",
+  "examples/mtp",
   "examples/simple",
   "examples/reranker",
   "examples/mtmd",

--- a/examples/mtp-compare/Cargo.toml
+++ b/examples/mtp-compare/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mtp-compare"
+version = "0.1.147"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+encoding_rs = { workspace = true }
+hf-hub = { workspace = true }
+llama-cpp-2 = { path = "../../llama-cpp-2" }
+
+[features]
+cuda = ["llama-cpp-2/cuda"]
+metal = ["llama-cpp-2/metal"]
+vulkan = ["llama-cpp-2/vulkan"]
+
+[lints]
+workspace = true

--- a/examples/mtp-compare/src/main.rs
+++ b/examples/mtp-compare/src/main.rs
@@ -52,9 +52,14 @@ struct Args {
 
 #[derive(clap::Subcommand, Debug, Clone)]
 enum ModelSource {
-    Local { path: PathBuf },
+    Local {
+        path: PathBuf,
+    },
     #[clap(name = "hf-model")]
-    HuggingFace { repo: String, model: String },
+    HuggingFace {
+        repo: String,
+        model: String,
+    },
 }
 
 impl ModelSource {
@@ -139,7 +144,14 @@ fn main() -> Result<()> {
     }
 
     let plain = run_plain(&backend, &model, &prompt_tokens, n_predict, ctx_size)?;
-    let mtp = run_mtp(&backend, &model, &prompt_tokens, n_predict, draft_n, ctx_size)?;
+    let mtp = run_mtp(
+        &backend,
+        &model,
+        &prompt_tokens,
+        n_predict,
+        draft_n,
+        ctx_size,
+    )?;
 
     print_stats(&plain);
     println!();
@@ -287,7 +299,8 @@ fn run_mtp(
 
     let start = Instant::now();
     let eos = model.token_eos();
-    let n_embd = usize::try_from(model.n_embd()).with_context(|| "n_embd does not fit into usize")?;
+    let n_embd =
+        usize::try_from(model.n_embd()).with_context(|| "n_embd does not fit into usize")?;
 
     prefill_target(&mut target, prompt_tokens)?;
     prefill_mtp_context(&mut draft, &target, prompt_tokens, n_embd)?;
@@ -369,9 +382,7 @@ fn ensure_model_has_mtp(path: &Path) -> Result<()> {
     let nextn_idx = gguf.find_key(&nextn_key);
 
     if nextn_idx < 0 {
-        bail!(
-            "model does not advertise bundled MTP layers; expected GGUF key `{nextn_key}`"
-        );
+        bail!("model does not advertise bundled MTP layers; expected GGUF key `{nextn_key}`");
     }
 
     if gguf.val_u32(nextn_idx) == 0 {
@@ -386,7 +397,8 @@ fn prefill_target(ctx: &mut LlamaContext, tokens: &[LlamaToken]) -> Result<()> {
     batch
         .add_sequence(tokens, 0, true)
         .map_err(anyhow::Error::from)?;
-    ctx.decode(&mut batch).with_context(|| "target prefill failed")?;
+    ctx.decode(&mut batch)
+        .with_context(|| "target prefill failed")?;
     Ok(())
 }
 
@@ -403,8 +415,7 @@ fn prefill_mtp_context(
         let embd = if i == 0 {
             zero.as_slice()
         } else {
-            target
-                .embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
+            target.embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
         };
         let logits = i + 1 == tokens.len();
         batch
@@ -471,15 +482,7 @@ fn accept_tokens(
 ) -> Result<Vec<LlamaToken>> {
     let first = greedy_token(target.get_logits());
     if drafted.first().copied() != Some(first) {
-        rollback_and_advance(
-            target,
-            draft,
-            prompt_len,
-            0,
-            first,
-            n_embd,
-            prefix_hidden,
-        )?;
+        rollback_and_advance(target, draft, prompt_len, 0, first, n_embd, prefix_hidden)?;
         return Ok(vec![first]);
     }
 
@@ -544,8 +547,8 @@ fn rollback_and_advance(
     n_embd: usize,
     extra_hidden: &[f32],
 ) -> Result<()> {
-    let rollback_pos =
-        u32::try_from(prompt_len + matched).with_context(|| "rollback position does not fit into u32")?;
+    let rollback_pos = u32::try_from(prompt_len + matched)
+        .with_context(|| "rollback position does not fit into u32")?;
 
     let target_rolled_back = target
         .clear_kv_cache_seq(Some(0), Some(rollback_pos), None)
@@ -561,8 +564,8 @@ fn rollback_and_advance(
         bail!("MTP draft KV rollback failed at position {rollback_pos}");
     }
 
-    let extra_pos =
-        i32::try_from(prompt_len + matched).with_context(|| "extra token position does not fit into i32")?;
+    let extra_pos = i32::try_from(prompt_len + matched)
+        .with_context(|| "extra token position does not fit into i32")?;
 
     let mut target_batch = LlamaBatch::new(1, 1);
     target_batch

--- a/examples/mtp-compare/src/main.rs
+++ b/examples/mtp-compare/src/main.rs
@@ -288,11 +288,11 @@ fn run_mtp(
         .with_context(|| "failed to create MTP draft context")?;
 
     target
-        .set_embeddings_pre_norm(true)
-        .with_context(|| "failed to enable target pre-norm embeddings")?;
+        .set_embeddings_nextn(true, true)
+        .with_context(|| "failed to enable target nextn embeddings")?;
     draft
-        .set_embeddings_pre_norm(true)
-        .with_context(|| "failed to enable MTP draft pre-norm embeddings")?;
+        .set_embeddings_nextn(true, true)
+        .with_context(|| "failed to enable MTP draft nextn embeddings")?;
 
     target.reset_timings();
     draft.reset_timings();
@@ -313,7 +313,7 @@ fn run_mtp(
     let mut accepted_tokens = 0usize;
 
     while generated_tokens < n_predict {
-        let prefix_hidden = target.embeddings_pre_norm()?.to_vec();
+        let prefix_hidden = target.embeddings_nextn()?.to_vec();
         let drafted = draft_tokens(&mut draft, n_embd, tokens.len(), draft_n, eos)?;
         if drafted.is_empty() {
             break;
@@ -415,7 +415,7 @@ fn prefill_mtp_context(
         let embd = if i == 0 {
             zero.as_slice()
         } else {
-            target.embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
+            target.embeddings_nextn_ith(i32::try_from(i - 1).expect("index fits into i32"))?
         };
         let logits = i + 1 == tokens.len();
         batch
@@ -443,7 +443,7 @@ fn draft_tokens(
     eos: LlamaToken,
 ) -> Result<Vec<LlamaToken>> {
     let mut drafted = Vec::with_capacity(draft_n);
-    let mut h_prev = draft.embeddings_pre_norm()?.to_vec();
+    let mut h_prev = draft.embeddings_nextn()?.to_vec();
 
     for step in 0..draft_n {
         let token = greedy_token(draft.get_logits());
@@ -466,7 +466,7 @@ fn draft_tokens(
         draft
             .decode(&mut batch)
             .with_context(|| "MTP draft step failed")?;
-        h_prev = draft.embeddings_pre_norm()?.to_vec();
+        h_prev = draft.embeddings_nextn()?.to_vec();
     }
 
     Ok(drafted)
@@ -521,7 +521,7 @@ fn accept_tokens(
         prefix_hidden.to_vec()
     } else {
         target
-            .embeddings_pre_norm_ith(i32::try_from(matched - 1).expect("index fits into i32"))?
+            .embeddings_nextn_ith(i32::try_from(matched - 1).expect("index fits into i32"))?
             .to_vec()
     };
 

--- a/examples/mtp-compare/src/main.rs
+++ b/examples/mtp-compare/src/main.rs
@@ -1,0 +1,616 @@
+//! Compare plain autoregressive decoding against Qwen3.5 MTP decoding.
+//!
+//! Example:
+//!
+//! ```console
+//! cargo run -p mtp-compare --release --features cuda -- \
+//!   --prompt "Write a short poem about Rust" \
+//!   --n-predict 64 \
+//!   --draft-n 4 \
+//!   hf-model unsloth/Qwen3.5-4B-MTP-GGUF Qwen3.5-4B-Q4_K_M.gguf
+//! ```
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use std::io::Write;
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use hf_hub::api::sync::ApiBuilder;
+use llama_cpp_2::context::params::{LlamaContextParams, LlamaContextType};
+use llama_cpp_2::context::LlamaContext;
+use llama_cpp_2::gguf::GgufContext;
+use llama_cpp_2::llama_backend::LlamaBackend;
+use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::model::params::LlamaModelParams;
+use llama_cpp_2::model::{AddBos, LlamaModel};
+use llama_cpp_2::timing::LlamaTimings;
+use llama_cpp_2::token::LlamaToken;
+
+#[derive(Parser, Debug, Clone)]
+struct Args {
+    #[command(subcommand)]
+    model: ModelSource,
+    #[arg(short = 'p', long, default_value = "Write a short poem about Rust.")]
+    prompt: String,
+    #[arg(long, default_value_t = 64)]
+    n_predict: usize,
+    #[arg(long, default_value_t = 4)]
+    draft_n: usize,
+    #[arg(short = 'c', long)]
+    ctx_size: Option<NonZeroU32>,
+    #[cfg(any(feature = "cuda", feature = "vulkan"))]
+    #[arg(long)]
+    disable_gpu: bool,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+enum ModelSource {
+    Local { path: PathBuf },
+    #[clap(name = "hf-model")]
+    HuggingFace { repo: String, model: String },
+}
+
+impl ModelSource {
+    fn get_or_load(self) -> Result<PathBuf> {
+        match self {
+            Self::Local { path } => Ok(path),
+            Self::HuggingFace { repo, model } => ApiBuilder::new()
+                .with_progress(true)
+                .build()
+                .with_context(|| "unable to create Hugging Face API")?
+                .model(repo)
+                .get(&model)
+                .with_context(|| "unable to download model"),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RunStats {
+    mode: &'static str,
+    output: String,
+    wall_ms: f64,
+    generated_tokens: usize,
+    prompt_tokens: usize,
+    timings: LlamaTimings,
+    drafted_tokens: usize,
+    accepted_tokens: usize,
+}
+
+impl RunStats {
+    fn wall_tps(&self) -> f64 {
+        if self.wall_ms <= 0.0 {
+            0.0
+        } else {
+            1e3 * self.generated_tokens as f64 / self.wall_ms
+        }
+    }
+
+    fn eval_tps(&self) -> f64 {
+        if self.timings.t_eval_ms() <= 0.0 {
+            0.0
+        } else {
+            1e3 * self.timings.n_eval() as f64 / self.timings.t_eval_ms()
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let Args {
+        model,
+        prompt,
+        n_predict,
+        draft_n,
+        ctx_size,
+        #[cfg(any(feature = "cuda", feature = "vulkan"))]
+        disable_gpu,
+    } = Args::parse();
+
+    let model_path = model.get_or_load()?;
+    ensure_model_has_mtp(&model_path)?;
+
+    let backend = LlamaBackend::init()?;
+    let model_params = {
+        #[cfg(any(feature = "cuda", feature = "vulkan"))]
+        if !disable_gpu {
+            LlamaModelParams::default().with_n_gpu_layers(1000)
+        } else {
+            LlamaModelParams::default()
+        }
+        #[cfg(not(any(feature = "cuda", feature = "vulkan")))]
+        LlamaModelParams::default()
+    };
+
+    let model = LlamaModel::load_from_file(&backend, &model_path, &model_params)
+        .with_context(|| format!("unable to load model from {}", model_path.display()))?;
+
+    let prompt_tokens = model
+        .str_to_token(&prompt, AddBos::Always)
+        .with_context(|| "failed to tokenize prompt")?;
+    if prompt_tokens.is_empty() {
+        bail!("prompt tokenized to an empty token list");
+    }
+
+    let plain = run_plain(&backend, &model, &prompt_tokens, n_predict, ctx_size)?;
+    let mtp = run_mtp(&backend, &model, &prompt_tokens, n_predict, draft_n, ctx_size)?;
+
+    print_stats(&plain);
+    println!();
+    print_stats(&mtp);
+    println!();
+    println!(
+        "Speedup: wall {:.2}x, eval {:.2}x",
+        safe_ratio(mtp.wall_tps(), plain.wall_tps()),
+        safe_ratio(mtp.eval_tps(), plain.eval_tps())
+    );
+
+    Ok(())
+}
+
+fn print_stats(stats: &RunStats) {
+    println!("== {} ==", stats.mode);
+    println!("Prompt tokens: {}", stats.prompt_tokens);
+    println!("Generated tokens: {}", stats.generated_tokens);
+    println!("Wall time: {:.2} ms", stats.wall_ms);
+    println!("Wall throughput: {:.2} tok/s", stats.wall_tps());
+    println!("Eval throughput: {:.2} tok/s", stats.eval_tps());
+    println!(
+        "Prompt eval: {:.2} ms over {} tokens",
+        stats.timings.t_p_eval_ms(),
+        stats.timings.n_p_eval()
+    );
+    println!(
+        "Eval: {:.2} ms over {} tokens",
+        stats.timings.t_eval_ms(),
+        stats.timings.n_eval()
+    );
+    if stats.drafted_tokens > 0 {
+        println!(
+            "Drafted tokens: {}, accepted tokens: {}, acceptance rate: {:.2}%",
+            stats.drafted_tokens,
+            stats.accepted_tokens,
+            100.0 * stats.accepted_tokens as f64 / stats.drafted_tokens as f64
+        );
+    }
+    println!("Output:\n{}", stats.output);
+}
+
+fn run_plain(
+    backend: &LlamaBackend,
+    model: &LlamaModel,
+    prompt_tokens: &[LlamaToken],
+    n_predict: usize,
+    ctx_size: Option<NonZeroU32>,
+) -> Result<RunStats> {
+    let n_batch = prompt_tokens.len() + n_predict + 1;
+    let n_batch_u32 = u32::try_from(n_batch).with_context(|| "batch size does not fit into u32")?;
+    let ctx_params = LlamaContextParams::default()
+        .with_n_ctx(ctx_size)
+        .with_n_batch(n_batch_u32)
+        .with_n_ubatch(n_batch_u32);
+
+    let mut ctx = model
+        .new_context(backend, ctx_params)
+        .with_context(|| "failed to create plain context")?;
+    ctx.reset_timings();
+
+    let start = Instant::now();
+    prefill_target(&mut ctx, prompt_tokens)?;
+
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+    let mut output = String::new();
+    let eos = model.token_eos();
+    let mut generated_tokens = 0usize;
+    let mut next_pos = prompt_tokens.len();
+
+    while generated_tokens < n_predict {
+        let token = greedy_token(ctx.get_logits());
+        if token == eos {
+            break;
+        }
+
+        append_token(model, &mut decoder, &mut output, token)?;
+        generated_tokens += 1;
+
+        let mut batch = LlamaBatch::new(1, 1);
+        batch
+            .add(
+                token,
+                i32::try_from(next_pos).expect("position fits into i32"),
+                &[0],
+                true,
+            )
+            .map_err(anyhow::Error::from)?;
+        ctx.decode(&mut batch)
+            .with_context(|| "plain decode step failed")?;
+        next_pos += 1;
+    }
+
+    Ok(RunStats {
+        mode: "Plain",
+        output,
+        wall_ms: start.elapsed().as_secs_f64() * 1e3,
+        generated_tokens,
+        prompt_tokens: prompt_tokens.len(),
+        timings: ctx.timings(),
+        drafted_tokens: 0,
+        accepted_tokens: 0,
+    })
+}
+
+fn run_mtp(
+    backend: &LlamaBackend,
+    model: &LlamaModel,
+    prompt_tokens: &[LlamaToken],
+    n_predict: usize,
+    draft_n: usize,
+    ctx_size: Option<NonZeroU32>,
+) -> Result<RunStats> {
+    let n_batch = prompt_tokens.len() + n_predict + draft_n + 1;
+    let n_batch_u32 = u32::try_from(n_batch).with_context(|| "batch size does not fit into u32")?;
+    let n_rs_seq_u32 = u32::try_from(draft_n).with_context(|| "draft_n does not fit into u32")?;
+
+    let base_ctx_params = LlamaContextParams::default()
+        .with_n_ctx(ctx_size)
+        .with_n_rs_seq(n_rs_seq_u32)
+        .with_n_batch(n_batch_u32)
+        .with_n_ubatch(n_batch_u32);
+
+    let mut target = model
+        .new_context(backend, base_ctx_params.clone())
+        .with_context(|| "failed to create target context")?;
+    let mut draft = model
+        .new_context(
+            backend,
+            base_ctx_params
+                .with_ctx_type(LlamaContextType::Mtp)
+                .with_n_rs_seq(n_rs_seq_u32),
+        )
+        .with_context(|| "failed to create MTP draft context")?;
+
+    target
+        .set_embeddings_pre_norm(true)
+        .with_context(|| "failed to enable target pre-norm embeddings")?;
+    draft
+        .set_embeddings_pre_norm(true)
+        .with_context(|| "failed to enable MTP draft pre-norm embeddings")?;
+
+    target.reset_timings();
+    draft.reset_timings();
+
+    let start = Instant::now();
+    let eos = model.token_eos();
+    let n_embd = usize::try_from(model.n_embd()).with_context(|| "n_embd does not fit into usize")?;
+
+    prefill_target(&mut target, prompt_tokens)?;
+    prefill_mtp_context(&mut draft, &target, prompt_tokens, n_embd)?;
+
+    let mut tokens = prompt_tokens.to_vec();
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+    let mut output = String::new();
+    let mut generated_tokens = 0usize;
+    let mut drafted_tokens = 0usize;
+    let mut accepted_tokens = 0usize;
+
+    while generated_tokens < n_predict {
+        let prefix_hidden = target.embeddings_pre_norm()?.to_vec();
+        let drafted = draft_tokens(&mut draft, n_embd, tokens.len(), draft_n, eos)?;
+        if drafted.is_empty() {
+            break;
+        }
+        drafted_tokens += drafted.len();
+
+        let accepted = accept_tokens(
+            &mut target,
+            &mut draft,
+            &drafted,
+            tokens.len(),
+            n_embd,
+            &prefix_hidden,
+        )?;
+        accepted_tokens += accepted.len().min(drafted.len());
+
+        for token in accepted {
+            if token == eos || generated_tokens >= n_predict {
+                return Ok(RunStats {
+                    mode: "MTP",
+                    output,
+                    wall_ms: start.elapsed().as_secs_f64() * 1e3,
+                    generated_tokens,
+                    prompt_tokens: prompt_tokens.len(),
+                    timings: target.timings(),
+                    drafted_tokens,
+                    accepted_tokens,
+                });
+            }
+
+            append_token(model, &mut decoder, &mut output, token)?;
+            tokens.push(token);
+            generated_tokens += 1;
+
+            if generated_tokens >= n_predict {
+                break;
+            }
+        }
+    }
+
+    Ok(RunStats {
+        mode: "MTP",
+        output,
+        wall_ms: start.elapsed().as_secs_f64() * 1e3,
+        generated_tokens,
+        prompt_tokens: prompt_tokens.len(),
+        timings: target.timings(),
+        drafted_tokens,
+        accepted_tokens,
+    })
+}
+
+fn ensure_model_has_mtp(path: &Path) -> Result<()> {
+    let gguf = GgufContext::from_file(path)
+        .with_context(|| format!("unable to inspect GGUF metadata at {}", path.display()))?;
+
+    let arch_key = gguf.find_key("general.architecture");
+    if arch_key < 0 {
+        bail!("GGUF is missing general.architecture");
+    }
+
+    let arch = gguf
+        .val_str(arch_key)
+        .with_context(|| "general.architecture is not a valid string")?;
+    let nextn_key = format!("{arch}.nextn_predict_layers");
+    let nextn_idx = gguf.find_key(&nextn_key);
+
+    if nextn_idx < 0 {
+        bail!(
+            "model does not advertise bundled MTP layers; expected GGUF key `{nextn_key}`"
+        );
+    }
+
+    if gguf.val_u32(nextn_idx) == 0 {
+        bail!("GGUF key `{nextn_key}` is present but disabled");
+    }
+
+    Ok(())
+}
+
+fn prefill_target(ctx: &mut LlamaContext, tokens: &[LlamaToken]) -> Result<()> {
+    let mut batch = LlamaBatch::new(tokens.len(), 1);
+    batch
+        .add_sequence(tokens, 0, true)
+        .map_err(anyhow::Error::from)?;
+    ctx.decode(&mut batch).with_context(|| "target prefill failed")?;
+    Ok(())
+}
+
+fn prefill_mtp_context(
+    draft: &mut LlamaContext,
+    target: &LlamaContext,
+    tokens: &[LlamaToken],
+    n_embd: usize,
+) -> Result<()> {
+    let mut batch = LlamaBatch::new_with_embeddings(tokens.len(), n_embd, 1);
+    let zero = vec![0.0_f32; n_embd];
+
+    for (i, token) in tokens.iter().enumerate() {
+        let embd = if i == 0 {
+            zero.as_slice()
+        } else {
+            target
+                .embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
+        };
+        let logits = i + 1 == tokens.len();
+        batch
+            .add_with_embedding(
+                *token,
+                embd,
+                i32::try_from(i).expect("position fits into i32"),
+                &[0],
+                logits,
+            )
+            .map_err(anyhow::Error::from)?;
+    }
+
+    draft
+        .decode(&mut batch)
+        .with_context(|| "MTP draft prefill failed")?;
+    Ok(())
+}
+
+fn draft_tokens(
+    draft: &mut LlamaContext,
+    n_embd: usize,
+    prompt_len: usize,
+    draft_n: usize,
+    eos: LlamaToken,
+) -> Result<Vec<LlamaToken>> {
+    let mut drafted = Vec::with_capacity(draft_n);
+    let mut h_prev = draft.embeddings_pre_norm()?.to_vec();
+
+    for step in 0..draft_n {
+        let token = greedy_token(draft.get_logits());
+        drafted.push(token);
+        if token == eos {
+            break;
+        }
+
+        let mut batch = LlamaBatch::new_with_embeddings(1, n_embd, 1);
+        batch
+            .add_with_embedding(
+                token,
+                &h_prev,
+                i32::try_from(prompt_len + step).expect("position fits into i32"),
+                &[0],
+                true,
+            )
+            .map_err(anyhow::Error::from)?;
+
+        draft
+            .decode(&mut batch)
+            .with_context(|| "MTP draft step failed")?;
+        h_prev = draft.embeddings_pre_norm()?.to_vec();
+    }
+
+    Ok(drafted)
+}
+
+fn accept_tokens(
+    target: &mut LlamaContext,
+    draft: &mut LlamaContext,
+    drafted: &[LlamaToken],
+    prompt_len: usize,
+    n_embd: usize,
+    prefix_hidden: &[f32],
+) -> Result<Vec<LlamaToken>> {
+    let first = greedy_token(target.get_logits());
+    if drafted.first().copied() != Some(first) {
+        rollback_and_advance(
+            target,
+            draft,
+            prompt_len,
+            0,
+            first,
+            n_embd,
+            prefix_hidden,
+        )?;
+        return Ok(vec![first]);
+    }
+
+    let mut batch = LlamaBatch::new(drafted.len(), 1);
+    for (i, token) in drafted.iter().enumerate() {
+        batch
+            .add(
+                *token,
+                i32::try_from(prompt_len + i).expect("position fits into i32"),
+                &[0],
+                true,
+            )
+            .map_err(anyhow::Error::from)?;
+    }
+
+    target
+        .decode(&mut batch)
+        .with_context(|| "target verification decode failed")?;
+
+    let mut matched = 0usize;
+    let mut extra = first;
+
+    for i in 0..drafted.len() {
+        let sampled = greedy_token(target.get_logits_ith(i32::try_from(i).expect("index fits")));
+        if i + 1 == drafted.len() || sampled != drafted[i + 1] {
+            matched = i + 1;
+            extra = sampled;
+            break;
+        }
+    }
+
+    let mut accepted = drafted[..matched].to_vec();
+    accepted.push(extra);
+
+    let extra_hidden = if matched == 0 {
+        prefix_hidden.to_vec()
+    } else {
+        target
+            .embeddings_pre_norm_ith(i32::try_from(matched - 1).expect("index fits into i32"))?
+            .to_vec()
+    };
+
+    rollback_and_advance(
+        target,
+        draft,
+        prompt_len,
+        matched,
+        extra,
+        n_embd,
+        &extra_hidden,
+    )?;
+
+    Ok(accepted)
+}
+
+fn rollback_and_advance(
+    target: &mut LlamaContext,
+    draft: &mut LlamaContext,
+    prompt_len: usize,
+    matched: usize,
+    extra: LlamaToken,
+    n_embd: usize,
+    extra_hidden: &[f32],
+) -> Result<()> {
+    let rollback_pos =
+        u32::try_from(prompt_len + matched).with_context(|| "rollback position does not fit into u32")?;
+
+    let target_rolled_back = target
+        .clear_kv_cache_seq(Some(0), Some(rollback_pos), None)
+        .with_context(|| "failed to roll back target KV cache")?;
+    if !target_rolled_back {
+        bail!("target KV rollback failed at position {rollback_pos}");
+    }
+
+    let draft_rolled_back = draft
+        .clear_kv_cache_seq(Some(0), Some(rollback_pos), None)
+        .with_context(|| "failed to roll back MTP draft KV cache")?;
+    if !draft_rolled_back {
+        bail!("MTP draft KV rollback failed at position {rollback_pos}");
+    }
+
+    let extra_pos =
+        i32::try_from(prompt_len + matched).with_context(|| "extra token position does not fit into i32")?;
+
+    let mut target_batch = LlamaBatch::new(1, 1);
+    target_batch
+        .add(extra, extra_pos, &[0], true)
+        .map_err(anyhow::Error::from)?;
+    target
+        .decode(&mut target_batch)
+        .with_context(|| "failed to advance target with accepted token")?;
+
+    let mut draft_batch = LlamaBatch::new_with_embeddings(1, n_embd, 1);
+    draft_batch
+        .add_with_embedding(extra, extra_hidden, extra_pos, &[0], true)
+        .map_err(anyhow::Error::from)?;
+    draft
+        .decode(&mut draft_batch)
+        .with_context(|| "failed to advance MTP draft with accepted token")?;
+
+    Ok(())
+}
+
+fn greedy_token(logits: &[f32]) -> LlamaToken {
+    let (idx, _) = logits
+        .iter()
+        .copied()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+        .expect("logits must not be empty");
+    LlamaToken::new(i32::try_from(idx).expect("token index fits into i32"))
+}
+
+fn append_token(
+    model: &LlamaModel,
+    decoder: &mut encoding_rs::Decoder,
+    output: &mut String,
+    token: LlamaToken,
+) -> Result<()> {
+    let piece = model
+        .token_to_piece(token, decoder, true, None)
+        .with_context(|| format!("failed to decode token {token}"))?;
+    output.push_str(&piece);
+    std::io::stdout().flush()?;
+    Ok(())
+}
+
+fn safe_ratio(numerator: f64, denominator: f64) -> f64 {
+    if denominator <= 0.0 {
+        0.0
+    } else {
+        numerator / denominator
+    }
+}

--- a/examples/mtp/Cargo.toml
+++ b/examples/mtp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mtp-example"
+version = "0.1.147"
+edition = "2021"
+publish = false
+
+[dependencies]
+llama-cpp-2 = { path = "../../llama-cpp-2", version = "0.1.147" }
+hf-hub = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+encoding_rs = { workspace = true }
+
+[features]
+cuda = ["llama-cpp-2/cuda"]
+metal = ["llama-cpp-2/metal"]
+vulkan = ["llama-cpp-2/vulkan"]
+
+[lints]
+workspace = true

--- a/examples/mtp/src/main.rs
+++ b/examples/mtp/src/main.rs
@@ -126,9 +126,11 @@ fn main() -> Result<()> {
 
     let n_batch = tokens.len() + n_predict + draft_n + 1;
     let n_batch_u32 = u32::try_from(n_batch).with_context(|| "batch size does not fit into u32")?;
+    let n_rs_seq_u32 = u32::try_from(draft_n).with_context(|| "draft_n does not fit into u32")?;
 
     let base_ctx_params = LlamaContextParams::default()
         .with_n_ctx(ctx_size)
+        .with_n_rs_seq(n_rs_seq_u32)
         .with_n_batch(n_batch_u32)
         .with_n_ubatch(n_batch_u32);
 
@@ -141,7 +143,7 @@ fn main() -> Result<()> {
             &backend,
             base_ctx_params
                 .with_ctx_type(LlamaContextType::Mtp)
-                .with_n_rs_seq(0),
+                .with_n_rs_seq(n_rs_seq_u32),
         )
         .with_context(|| "failed to create MTP draft context")?;
 
@@ -157,22 +159,25 @@ fn main() -> Result<()> {
     let mut decoder = encoding_rs::UTF_8.new_decoder();
     let mut generated = 0usize;
 
+    prefill_target(&mut target, &tokens)?;
+    prefill_mtp_context(&mut draft, &target, &tokens, n_embd)?;
+
     while generated < n_predict {
-        target.clear_kv_cache();
-        draft.clear_kv_cache();
-
-        prefill_target(&mut target, &tokens)?;
-        prefill_mtp_context(&mut draft, &target, &tokens, n_embd)?;
-
+        let prefix_hidden = target.embeddings_pre_norm()?.to_vec();
         let drafted = draft_tokens(&mut draft, n_embd, tokens.len(), draft_n, eos)?;
         if drafted.is_empty() {
             break;
         }
 
-        let accepted = accept_tokens(&mut target, &drafted, tokens.len(), eos)?;
-        if accepted.is_empty() {
-            break;
-        }
+        let accepted = accept_tokens(
+            &mut target,
+            &mut draft,
+            &drafted,
+            tokens.len(),
+            eos,
+            n_embd,
+            &prefix_hidden,
+        )?;
 
         for token in &accepted {
             let piece = model
@@ -305,16 +310,26 @@ fn draft_tokens(
 
 fn accept_tokens(
     target: &mut LlamaContext,
+    draft: &mut LlamaContext,
     drafted: &[LlamaToken],
     prompt_len: usize,
-    eos: LlamaToken,
+    _eos: LlamaToken,
+    n_embd: usize,
+    prefix_hidden: &[f32],
 ) -> Result<Vec<LlamaToken>> {
     let first = greedy_token(target.get_logits());
     if drafted.first().copied() != Some(first) {
+        rollback_and_advance(
+            target,
+            draft,
+            prompt_len,
+            0,
+            first,
+            n_embd,
+            prefix_hidden,
+        )?;
         return Ok(vec![first]);
     }
-
-    let mut accepted = vec![first];
 
     let mut batch = LlamaBatch::new(drafted.len(), 1);
     for (i, token) in drafted.iter().enumerate() {
@@ -332,19 +347,88 @@ fn accept_tokens(
         .decode(&mut batch)
         .with_context(|| "target verification decode failed")?;
 
+    let mut matched = 0usize;
+    let mut extra = first;
+
     for i in 0..drafted.len() {
         let sampled = greedy_token(target.get_logits_ith(i32::try_from(i).expect("index fits")));
         if i + 1 == drafted.len() || sampled != drafted[i + 1] {
-            accepted.push(sampled);
-            break;
-        }
-        accepted.push(drafted[i + 1]);
-        if sampled == eos {
+            matched = i + 1;
+            extra = sampled;
             break;
         }
     }
 
+    let mut accepted = drafted[..matched].to_vec();
+    accepted.push(extra);
+
+    let extra_hidden = if matched == 0 {
+        prefix_hidden.to_vec()
+    } else {
+        target
+            .embeddings_pre_norm_ith(i32::try_from(matched - 1).expect("index fits into i32"))?
+            .to_vec()
+    };
+
+    rollback_and_advance(
+        target,
+        draft,
+        prompt_len,
+        matched,
+        extra,
+        n_embd,
+        &extra_hidden,
+    )?;
+
     Ok(accepted)
+}
+
+fn rollback_and_advance(
+    target: &mut LlamaContext,
+    draft: &mut LlamaContext,
+    prompt_len: usize,
+    matched: usize,
+    extra: LlamaToken,
+    n_embd: usize,
+    extra_hidden: &[f32],
+) -> Result<()> {
+    let rollback_pos =
+        u32::try_from(prompt_len + matched).with_context(|| "rollback position does not fit into u32")?;
+
+    let target_rolled_back = target
+        .clear_kv_cache_seq(Some(0), Some(rollback_pos), None)
+        .with_context(|| "failed to roll back target KV cache")?;
+    if !target_rolled_back {
+        bail!("target KV rollback failed at position {rollback_pos}");
+    }
+
+    let draft_rolled_back = draft
+        .clear_kv_cache_seq(Some(0), Some(rollback_pos), None)
+        .with_context(|| "failed to roll back MTP draft KV cache")?;
+    if !draft_rolled_back {
+        bail!("MTP draft KV rollback failed at position {rollback_pos}");
+    }
+
+    let extra_pos =
+        i32::try_from(prompt_len + matched).with_context(|| "extra token position does not fit into i32")?;
+
+    let mut target_batch = LlamaBatch::new(1, 1);
+    target_batch
+        .add(extra, extra_pos, &[0], true)
+        .map_err(anyhow::Error::from)?;
+    target
+        .decode(&mut target_batch)
+        .with_context(|| "failed to advance target with accepted token")?;
+
+    let mut draft_batch = LlamaBatch::new_with_embeddings(1, n_embd, 1);
+    draft_batch
+        .add_with_embedding(extra, extra_hidden, extra_pos, &[0], true)
+        .map_err(anyhow::Error::from)?;
+    draft
+        .decode(&mut draft_batch)
+        .with_context(|| "failed to advance MTP draft with accepted token")?;
+
+    Ok(())
 }
 
 fn greedy_token(logits: &[f32]) -> LlamaToken {

--- a/examples/mtp/src/main.rs
+++ b/examples/mtp/src/main.rs
@@ -148,11 +148,11 @@ fn main() -> Result<()> {
         .with_context(|| "failed to create MTP draft context")?;
 
     target
-        .set_embeddings_pre_norm(true)
-        .with_context(|| "failed to enable target pre-norm embeddings")?;
+        .set_embeddings_nextn(true, true)
+        .with_context(|| "failed to enable target nextn embeddings")?;
     draft
-        .set_embeddings_pre_norm(true)
-        .with_context(|| "failed to enable MTP draft pre-norm embeddings")?;
+        .set_embeddings_nextn(true, true)
+        .with_context(|| "failed to enable MTP draft nextn embeddings")?;
 
     let eos = model.token_eos();
     let n_embd =
@@ -164,7 +164,7 @@ fn main() -> Result<()> {
     prefill_mtp_context(&mut draft, &target, &tokens, n_embd)?;
 
     while generated < n_predict {
-        let prefix_hidden = target.embeddings_pre_norm()?.to_vec();
+        let prefix_hidden = target.embeddings_nextn()?.to_vec();
         let drafted = draft_tokens(&mut draft, n_embd, tokens.len(), draft_n, eos)?;
         if drafted.is_empty() {
             break;
@@ -250,7 +250,7 @@ fn prefill_mtp_context(
         let embd = if i == 0 {
             zero.as_slice()
         } else {
-            target.embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
+            target.embeddings_nextn_ith(i32::try_from(i - 1).expect("index fits into i32"))?
         };
         let logits = i + 1 == tokens.len();
         batch
@@ -278,7 +278,7 @@ fn draft_tokens(
     eos: LlamaToken,
 ) -> Result<Vec<LlamaToken>> {
     let mut drafted = Vec::with_capacity(draft_n);
-    let mut h_prev = draft.embeddings_pre_norm()?.to_vec();
+    let mut h_prev = draft.embeddings_nextn()?.to_vec();
 
     for step in 0..draft_n {
         let token = greedy_token(draft.get_logits());
@@ -301,7 +301,7 @@ fn draft_tokens(
         draft
             .decode(&mut batch)
             .with_context(|| "MTP draft step failed")?;
-        h_prev = draft.embeddings_pre_norm()?.to_vec();
+        h_prev = draft.embeddings_nextn()?.to_vec();
     }
 
     Ok(drafted)
@@ -357,7 +357,7 @@ fn accept_tokens(
         prefix_hidden.to_vec()
     } else {
         target
-            .embeddings_pre_norm_ith(i32::try_from(matched - 1).expect("index fits into i32"))?
+            .embeddings_nextn_ith(i32::try_from(matched - 1).expect("index fits into i32"))?
             .to_vec()
     };
 

--- a/examples/mtp/src/main.rs
+++ b/examples/mtp/src/main.rs
@@ -155,7 +155,8 @@ fn main() -> Result<()> {
         .with_context(|| "failed to enable MTP draft pre-norm embeddings")?;
 
     let eos = model.token_eos();
-    let n_embd = usize::try_from(model.n_embd()).with_context(|| "n_embd does not fit into usize")?;
+    let n_embd =
+        usize::try_from(model.n_embd()).with_context(|| "n_embd does not fit into usize")?;
     let mut decoder = encoding_rs::UTF_8.new_decoder();
     let mut generated = 0usize;
 
@@ -216,9 +217,7 @@ fn ensure_model_has_mtp(path: &Path) -> Result<()> {
     let nextn_idx = gguf.find_key(&nextn_key);
 
     if nextn_idx < 0 {
-        bail!(
-            "model does not advertise bundled MTP layers; expected GGUF key `{nextn_key}`"
-        );
+        bail!("model does not advertise bundled MTP layers; expected GGUF key `{nextn_key}`");
     }
 
     if gguf.val_u32(nextn_idx) == 0 {
@@ -233,7 +232,8 @@ fn prefill_target(ctx: &mut LlamaContext, tokens: &[LlamaToken]) -> Result<()> {
     batch
         .add_sequence(tokens, 0, true)
         .map_err(anyhow::Error::from)?;
-    ctx.decode(&mut batch).with_context(|| "target prefill failed")?;
+    ctx.decode(&mut batch)
+        .with_context(|| "target prefill failed")?;
     Ok(())
 }
 
@@ -250,8 +250,7 @@ fn prefill_mtp_context(
         let embd = if i == 0 {
             zero.as_slice()
         } else {
-            target
-                .embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
+            target.embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
         };
         let logits = i + 1 == tokens.len();
         batch
@@ -319,15 +318,7 @@ fn accept_tokens(
 ) -> Result<Vec<LlamaToken>> {
     let first = greedy_token(target.get_logits());
     if drafted.first().copied() != Some(first) {
-        rollback_and_advance(
-            target,
-            draft,
-            prompt_len,
-            0,
-            first,
-            n_embd,
-            prefix_hidden,
-        )?;
+        rollback_and_advance(target, draft, prompt_len, 0, first, n_embd, prefix_hidden)?;
         return Ok(vec![first]);
     }
 
@@ -392,8 +383,8 @@ fn rollback_and_advance(
     n_embd: usize,
     extra_hidden: &[f32],
 ) -> Result<()> {
-    let rollback_pos =
-        u32::try_from(prompt_len + matched).with_context(|| "rollback position does not fit into u32")?;
+    let rollback_pos = u32::try_from(prompt_len + matched)
+        .with_context(|| "rollback position does not fit into u32")?;
 
     let target_rolled_back = target
         .clear_kv_cache_seq(Some(0), Some(rollback_pos), None)
@@ -409,8 +400,8 @@ fn rollback_and_advance(
         bail!("MTP draft KV rollback failed at position {rollback_pos}");
     }
 
-    let extra_pos =
-        i32::try_from(prompt_len + matched).with_context(|| "extra token position does not fit into i32")?;
+    let extra_pos = i32::try_from(prompt_len + matched)
+        .with_context(|| "extra token position does not fit into i32")?;
 
     let mut target_batch = LlamaBatch::new(1, 1);
     target_batch

--- a/examples/mtp/src/main.rs
+++ b/examples/mtp/src/main.rs
@@ -1,0 +1,358 @@
+//! Minimal MTP generation example for Qwen3.5-style GGUFs that include
+//! bundled NextN/MTP layers.
+//!
+//! Example:
+//!
+//! ```console
+//! cargo run -p mtp-example --release --features cuda -- \
+//!   --prompt "Write a short poem about Rust" \
+//!   --n-predict 64 \
+//!   --draft-n 4 \
+//!   hf-model unsloth/Qwen3.5-4B-MTP-GGUF Qwen3.5-4B-Q4_K_M.gguf
+//! ```
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use std::io::Write;
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use hf_hub::api::sync::ApiBuilder;
+use llama_cpp_2::context::params::{LlamaContextParams, LlamaContextType};
+use llama_cpp_2::context::LlamaContext;
+use llama_cpp_2::gguf::GgufContext;
+use llama_cpp_2::llama_backend::LlamaBackend;
+use llama_cpp_2::llama_batch::LlamaBatch;
+use llama_cpp_2::model::params::LlamaModelParams;
+use llama_cpp_2::model::{AddBos, LlamaModel};
+use llama_cpp_2::token::LlamaToken;
+
+#[derive(Parser, Debug, Clone)]
+struct Args {
+    /// The path to the model.
+    #[command(subcommand)]
+    model: ModelSource,
+    /// Prompt to generate from.
+    #[arg(short = 'p', long, default_value = "Write a short poem about Rust.")]
+    prompt: String,
+    /// Maximum number of tokens to generate.
+    #[arg(long, default_value_t = 64)]
+    n_predict: usize,
+    /// Maximum number of MTP draft tokens to attempt per iteration.
+    #[arg(long, default_value_t = 4)]
+    draft_n: usize,
+    /// Context size override.
+    #[arg(short = 'c', long)]
+    ctx_size: Option<NonZeroU32>,
+    /// Disable GPU offload.
+    #[cfg(any(feature = "cuda", feature = "vulkan"))]
+    #[arg(long)]
+    disable_gpu: bool,
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+enum ModelSource {
+    /// Use a local model path.
+    Local {
+        /// Local GGUF path.
+        path: PathBuf,
+    },
+    /// Download a model from Hugging Face.
+    #[clap(name = "hf-model")]
+    HuggingFace {
+        /// Hugging Face repository.
+        repo: String,
+        /// GGUF filename.
+        model: String,
+    },
+}
+
+impl ModelSource {
+    fn get_or_load(self) -> Result<PathBuf> {
+        match self {
+            Self::Local { path } => Ok(path),
+            Self::HuggingFace { repo, model } => ApiBuilder::new()
+                .with_progress(true)
+                .build()
+                .with_context(|| "unable to create Hugging Face API")?
+                .model(repo)
+                .get(&model)
+                .with_context(|| "unable to download model"),
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let Args {
+        model,
+        prompt,
+        n_predict,
+        draft_n,
+        ctx_size,
+        #[cfg(any(feature = "cuda", feature = "vulkan"))]
+        disable_gpu,
+    } = Args::parse();
+
+    let model_path = model.get_or_load()?;
+    ensure_model_has_mtp(&model_path)?;
+
+    let backend = LlamaBackend::init()?;
+    let model_params = {
+        #[cfg(any(feature = "cuda", feature = "vulkan"))]
+        if !disable_gpu {
+            LlamaModelParams::default().with_n_gpu_layers(1000)
+        } else {
+            LlamaModelParams::default()
+        }
+        #[cfg(not(any(feature = "cuda", feature = "vulkan")))]
+        LlamaModelParams::default()
+    };
+
+    let model = LlamaModel::load_from_file(&backend, &model_path, &model_params)
+        .with_context(|| format!("unable to load model from {}", model_path.display()))?;
+
+    let mut tokens = model
+        .str_to_token(&prompt, AddBos::Always)
+        .with_context(|| "failed to tokenize prompt")?;
+
+    if tokens.is_empty() {
+        bail!("prompt tokenized to an empty token list");
+    }
+
+    let n_batch = tokens.len() + n_predict + draft_n + 1;
+    let n_batch_u32 = u32::try_from(n_batch).with_context(|| "batch size does not fit into u32")?;
+
+    let base_ctx_params = LlamaContextParams::default()
+        .with_n_ctx(ctx_size)
+        .with_n_batch(n_batch_u32)
+        .with_n_ubatch(n_batch_u32);
+
+    let mut target = model
+        .new_context(&backend, base_ctx_params.clone())
+        .with_context(|| "failed to create target context")?;
+
+    let mut draft = model
+        .new_context(
+            &backend,
+            base_ctx_params
+                .with_ctx_type(LlamaContextType::Mtp)
+                .with_n_rs_seq(0),
+        )
+        .with_context(|| "failed to create MTP draft context")?;
+
+    target
+        .set_embeddings_pre_norm(true)
+        .with_context(|| "failed to enable target pre-norm embeddings")?;
+    draft
+        .set_embeddings_pre_norm(true)
+        .with_context(|| "failed to enable MTP draft pre-norm embeddings")?;
+
+    let eos = model.token_eos();
+    let n_embd = usize::try_from(model.n_embd()).with_context(|| "n_embd does not fit into usize")?;
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+    let mut generated = 0usize;
+
+    while generated < n_predict {
+        target.clear_kv_cache();
+        draft.clear_kv_cache();
+
+        prefill_target(&mut target, &tokens)?;
+        prefill_mtp_context(&mut draft, &target, &tokens, n_embd)?;
+
+        let drafted = draft_tokens(&mut draft, n_embd, tokens.len(), draft_n, eos)?;
+        if drafted.is_empty() {
+            break;
+        }
+
+        let accepted = accept_tokens(&mut target, &drafted, tokens.len(), eos)?;
+        if accepted.is_empty() {
+            break;
+        }
+
+        for token in &accepted {
+            let piece = model
+                .token_to_piece(*token, &mut decoder, true, None)
+                .with_context(|| format!("failed to decode token {token}"))?;
+            print!("{piece}");
+            std::io::stdout().flush()?;
+
+            tokens.push(*token);
+            generated += 1;
+
+            if *token == eos || generated >= n_predict {
+                println!();
+                return Ok(());
+            }
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+fn ensure_model_has_mtp(path: &Path) -> Result<()> {
+    let gguf = GgufContext::from_file(path)
+        .with_context(|| format!("unable to inspect GGUF metadata at {}", path.display()))?;
+
+    let arch_key = gguf.find_key("general.architecture");
+    if arch_key < 0 {
+        bail!("GGUF is missing general.architecture");
+    }
+
+    let arch = gguf
+        .val_str(arch_key)
+        .with_context(|| "general.architecture is not a valid string")?;
+    let nextn_key = format!("{arch}.nextn_predict_layers");
+    let nextn_idx = gguf.find_key(&nextn_key);
+
+    if nextn_idx < 0 {
+        bail!(
+            "model does not advertise bundled MTP layers; expected GGUF key `{nextn_key}`"
+        );
+    }
+
+    if gguf.val_u32(nextn_idx) == 0 {
+        bail!("GGUF key `{nextn_key}` is present but disabled");
+    }
+
+    Ok(())
+}
+
+fn prefill_target(ctx: &mut LlamaContext, tokens: &[LlamaToken]) -> Result<()> {
+    let mut batch = LlamaBatch::new(tokens.len(), 1);
+    batch
+        .add_sequence(tokens, 0, true)
+        .map_err(anyhow::Error::from)?;
+    ctx.decode(&mut batch).with_context(|| "target prefill failed")?;
+    Ok(())
+}
+
+fn prefill_mtp_context(
+    draft: &mut LlamaContext,
+    target: &LlamaContext,
+    tokens: &[LlamaToken],
+    n_embd: usize,
+) -> Result<()> {
+    let mut batch = LlamaBatch::new_with_embeddings(tokens.len(), n_embd, 1);
+    let zero = vec![0.0_f32; n_embd];
+
+    for (i, token) in tokens.iter().enumerate() {
+        let embd = if i == 0 {
+            zero.as_slice()
+        } else {
+            target
+                .embeddings_pre_norm_ith(i32::try_from(i - 1).expect("index fits into i32"))?
+        };
+        let logits = i + 1 == tokens.len();
+        batch
+            .add_with_embedding(
+                *token,
+                embd,
+                i32::try_from(i).expect("position fits into i32"),
+                &[0],
+                logits,
+            )
+            .map_err(anyhow::Error::from)?;
+    }
+
+    draft
+        .decode(&mut batch)
+        .with_context(|| "MTP draft prefill failed")?;
+    Ok(())
+}
+
+fn draft_tokens(
+    draft: &mut LlamaContext,
+    n_embd: usize,
+    prompt_len: usize,
+    draft_n: usize,
+    eos: LlamaToken,
+) -> Result<Vec<LlamaToken>> {
+    let mut drafted = Vec::with_capacity(draft_n);
+    let mut h_prev = draft.embeddings_pre_norm()?.to_vec();
+
+    for step in 0..draft_n {
+        let token = greedy_token(draft.get_logits());
+        drafted.push(token);
+        if token == eos {
+            break;
+        }
+
+        let mut batch = LlamaBatch::new_with_embeddings(1, n_embd, 1);
+        batch
+            .add_with_embedding(
+                token,
+                &h_prev,
+                i32::try_from(prompt_len + step).expect("position fits into i32"),
+                &[0],
+                true,
+            )
+            .map_err(anyhow::Error::from)?;
+
+        draft
+            .decode(&mut batch)
+            .with_context(|| "MTP draft step failed")?;
+        h_prev = draft.embeddings_pre_norm()?.to_vec();
+    }
+
+    Ok(drafted)
+}
+
+fn accept_tokens(
+    target: &mut LlamaContext,
+    drafted: &[LlamaToken],
+    prompt_len: usize,
+    eos: LlamaToken,
+) -> Result<Vec<LlamaToken>> {
+    let first = greedy_token(target.get_logits());
+    if drafted.first().copied() != Some(first) {
+        return Ok(vec![first]);
+    }
+
+    let mut accepted = vec![first];
+
+    let mut batch = LlamaBatch::new(drafted.len(), 1);
+    for (i, token) in drafted.iter().enumerate() {
+        batch
+            .add(
+                *token,
+                i32::try_from(prompt_len + i).expect("position fits into i32"),
+                &[0],
+                true,
+            )
+            .map_err(anyhow::Error::from)?;
+    }
+
+    target
+        .decode(&mut batch)
+        .with_context(|| "target verification decode failed")?;
+
+    for i in 0..drafted.len() {
+        let sampled = greedy_token(target.get_logits_ith(i32::try_from(i).expect("index fits")));
+        if i + 1 == drafted.len() || sampled != drafted[i + 1] {
+            accepted.push(sampled);
+            break;
+        }
+        accepted.push(drafted[i + 1]);
+        if sampled == eos {
+            break;
+        }
+    }
+
+    Ok(accepted)
+}
+
+fn greedy_token(logits: &[f32]) -> LlamaToken {
+    let (idx, _) = logits
+        .iter()
+        .copied()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+        .expect("logits must not be empty");
+    LlamaToken::new(i32::try_from(idx).expect("token index fits into i32"))
+}

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -365,7 +365,7 @@ impl<'model> LlamaContext<'model> {
 
     /// Print a breakdown of per-device memory use to the default logger.
     pub fn print_memory_breakdown(&self) {
-        unsafe { llama_cpp_sys_2::llama_memory_breakdown_print(self.context.as_ptr()) }
+        unsafe { llama_cpp_sys_2::llama_rs_memory_breakdown_print(self.context.as_ptr()) }
     }
 }
 

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -221,9 +221,12 @@ impl<'model> LlamaContext<'model> {
     }
 
     /// Get the nextn (MTP) embeddings buffer for the last decoded batch.
+    ///
+    /// Rows are `n_embd_out` floats wide: equal to `n_embd` for regular models, and the
+    /// projected target width for attached drafters (e.g. Gemma 4 assistants).
     pub fn embeddings_nextn(&self) -> Result<&[f32], EmbeddingsError> {
         let n_embd =
-            usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
+            usize::try_from(self.model.n_embd_out()).expect("n_embd_out does not fit into a usize");
 
         unsafe {
             let embedding = llama_cpp_sys_2::llama_rs_get_embeddings_nextn(self.context.as_ptr());
@@ -236,9 +239,12 @@ impl<'model> LlamaContext<'model> {
     }
 
     /// Get the nextn (MTP) embeddings for the `i`th token in the current context.
+    ///
+    /// Rows are `n_embd_out` floats wide: equal to `n_embd` for regular models, and the
+    /// projected target width for attached drafters (e.g. Gemma 4 assistants).
     pub fn embeddings_nextn_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
         let n_embd =
-            usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
+            usize::try_from(self.model.n_embd_out()).expect("n_embd_out does not fit into a usize");
 
         unsafe {
             let embedding =

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -70,6 +70,18 @@ impl<'model> LlamaContext<'model> {
         unsafe { llama_cpp_sys_2::llama_n_ctx(self.context.as_ptr()) }
     }
 
+    /// Gets the maximum number of sequences supported by this context.
+    #[must_use]
+    pub fn n_seq_max(&self) -> u32 {
+        unsafe { llama_cpp_sys_2::llama_n_seq_max(self.context.as_ptr()) }
+    }
+
+    /// Gets the number of recurrent-state snapshots supported by this context.
+    #[must_use]
+    pub fn n_rs_seq(&self) -> u32 {
+        unsafe { llama_cpp_sys_2::llama_n_rs_seq(self.context.as_ptr()) }
+    }
+
     /// Decodes the batch.
     ///
     /// # Errors
@@ -179,6 +191,60 @@ impl<'model> LlamaContext<'model> {
         unsafe {
             let embedding = llama_cpp_sys_2::llama_get_embeddings_ith(self.context.as_ptr(), i);
             // Technically also possible whenever `i >= batch.n_tokens`, but no good way of checking `n_tokens` here.
+            if embedding.is_null() {
+                Err(EmbeddingsError::LogitsNotEnabled)
+            } else {
+                Ok(slice::from_raw_parts(embedding, n_embd))
+            }
+        }
+    }
+
+    /// Enable or disable extraction of hidden states before the final output norm.
+    ///
+    /// Upstream uses this staging API for MTP/speculative decoding.
+    pub fn set_embeddings_pre_norm(&mut self, enabled: bool) -> Result<(), EmbeddingsError> {
+        if !self.embeddings_enabled {
+            return Err(EmbeddingsError::NotEnabled);
+        }
+
+        unsafe {
+            llama_cpp_sys_2::llama_rs_set_embeddings_pre_norm(self.context.as_ptr(), enabled);
+        }
+        Ok(())
+    }
+
+    /// Get the pre-norm embeddings for the last token in the context.
+    pub fn embeddings_pre_norm(&self) -> Result<&[f32], EmbeddingsError> {
+        if !self.embeddings_enabled {
+            return Err(EmbeddingsError::NotEnabled);
+        }
+
+        let n_embd =
+            usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
+
+        unsafe {
+            let embedding =
+                llama_cpp_sys_2::llama_rs_get_embeddings_pre_norm(self.context.as_ptr());
+            if embedding.is_null() {
+                Err(EmbeddingsError::LogitsNotEnabled)
+            } else {
+                Ok(slice::from_raw_parts(embedding, n_embd))
+            }
+        }
+    }
+
+    /// Get the pre-norm embeddings for the `i`th token in the current context.
+    pub fn embeddings_pre_norm_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
+        if !self.embeddings_enabled {
+            return Err(EmbeddingsError::NotEnabled);
+        }
+
+        let n_embd =
+            usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
+
+        unsafe {
+            let embedding =
+                llama_cpp_sys_2::llama_rs_get_embeddings_pre_norm_ith(self.context.as_ptr(), i);
             if embedding.is_null() {
                 Err(EmbeddingsError::LogitsNotEnabled)
             } else {

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -203,10 +203,6 @@ impl<'model> LlamaContext<'model> {
     ///
     /// Upstream uses this staging API for MTP/speculative decoding.
     pub fn set_embeddings_pre_norm(&mut self, enabled: bool) -> Result<(), EmbeddingsError> {
-        if !self.embeddings_enabled {
-            return Err(EmbeddingsError::NotEnabled);
-        }
-
         unsafe {
             llama_cpp_sys_2::llama_rs_set_embeddings_pre_norm(self.context.as_ptr(), enabled);
         }
@@ -215,10 +211,6 @@ impl<'model> LlamaContext<'model> {
 
     /// Get the pre-norm embeddings for the last token in the context.
     pub fn embeddings_pre_norm(&self) -> Result<&[f32], EmbeddingsError> {
-        if !self.embeddings_enabled {
-            return Err(EmbeddingsError::NotEnabled);
-        }
-
         let n_embd =
             usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
 
@@ -235,10 +227,6 @@ impl<'model> LlamaContext<'model> {
 
     /// Get the pre-norm embeddings for the `i`th token in the current context.
     pub fn embeddings_pre_norm_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
-        if !self.embeddings_enabled {
-            return Err(EmbeddingsError::NotEnabled);
-        }
-
         let n_embd =
             usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
 

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -199,24 +199,34 @@ impl<'model> LlamaContext<'model> {
         }
     }
 
-    /// Enable or disable extraction of hidden states before the final output norm.
+    /// Enable or disable extraction of nextn (MTP) hidden states.
     ///
     /// Upstream uses this staging API for MTP/speculative decoding.
-    pub fn set_embeddings_pre_norm(&mut self, enabled: bool) -> Result<(), EmbeddingsError> {
+    /// (Previously named `set_embeddings_pre_norm`; renamed upstream and the
+    /// extracted hidden state for some architectures is now post-norm.)
+    ///
+    /// When `masked` is `true`, embeddings are output only for tokens with
+    /// logits enabled in the batch and [`Self::embeddings_nextn_ith`] indexes
+    /// through output ids (matching the old pre-norm behavior). When `false`,
+    /// embeddings are output densely for every token in the batch.
+    pub fn set_embeddings_nextn(
+        &mut self,
+        enabled: bool,
+        masked: bool,
+    ) -> Result<(), EmbeddingsError> {
         unsafe {
-            llama_cpp_sys_2::llama_rs_set_embeddings_pre_norm(self.context.as_ptr(), enabled);
+            llama_cpp_sys_2::llama_rs_set_embeddings_nextn(self.context.as_ptr(), enabled, masked);
         }
         Ok(())
     }
 
-    /// Get the pre-norm embeddings for the last token in the context.
-    pub fn embeddings_pre_norm(&self) -> Result<&[f32], EmbeddingsError> {
+    /// Get the nextn (MTP) embeddings buffer for the last decoded batch.
+    pub fn embeddings_nextn(&self) -> Result<&[f32], EmbeddingsError> {
         let n_embd =
             usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
 
         unsafe {
-            let embedding =
-                llama_cpp_sys_2::llama_rs_get_embeddings_pre_norm(self.context.as_ptr());
+            let embedding = llama_cpp_sys_2::llama_rs_get_embeddings_nextn(self.context.as_ptr());
             if embedding.is_null() {
                 Err(EmbeddingsError::LogitsNotEnabled)
             } else {
@@ -225,14 +235,14 @@ impl<'model> LlamaContext<'model> {
         }
     }
 
-    /// Get the pre-norm embeddings for the `i`th token in the current context.
-    pub fn embeddings_pre_norm_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
+    /// Get the nextn (MTP) embeddings for the `i`th token in the current context.
+    pub fn embeddings_nextn_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
         let n_embd =
             usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
 
         unsafe {
             let embedding =
-                llama_cpp_sys_2::llama_rs_get_embeddings_pre_norm_ith(self.context.as_ptr(), i);
+                llama_cpp_sys_2::llama_rs_get_embeddings_nextn_ith(self.context.as_ptr(), i);
             if embedding.is_null() {
                 Err(EmbeddingsError::LogitsNotEnabled)
             } else {

--- a/llama-cpp-2/src/context/params.rs
+++ b/llama-cpp-2/src/context/params.rs
@@ -122,6 +122,34 @@ impl From<LlamaAttentionType> for i32 {
     }
 }
 
+/// A rusty wrapper around `llama_context_type`.
+#[repr(i8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LlamaContextType {
+    /// Standard llama.cpp context behavior.
+    Default = 0,
+    /// Multi-token prediction context behavior.
+    Mtp = 1,
+}
+
+impl From<u32> for LlamaContextType {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Self::Mtp,
+            _ => Self::Default,
+        }
+    }
+}
+
+impl From<LlamaContextType> for u32 {
+    fn from(value: LlamaContextType) -> Self {
+        match value {
+            LlamaContextType::Default => 0,
+            LlamaContextType::Mtp => 1,
+        }
+    }
+}
+
 /// A rusty wrapper around `ggml_type` for KV cache types.
 #[allow(non_camel_case_types, missing_docs)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/llama-cpp-2/src/context/params.rs
+++ b/llama-cpp-2/src/context/params.rs
@@ -141,7 +141,25 @@ impl From<u32> for LlamaContextType {
     }
 }
 
+impl From<i32> for LlamaContextType {
+    fn from(value: i32) -> Self {
+        match value {
+            1 => Self::Mtp,
+            _ => Self::Default,
+        }
+    }
+}
+
 impl From<LlamaContextType> for u32 {
+    fn from(value: LlamaContextType) -> Self {
+        match value {
+            LlamaContextType::Default => 0,
+            LlamaContextType::Mtp => 1,
+        }
+    }
+}
+
+impl From<LlamaContextType> for i32 {
     fn from(value: LlamaContextType) -> Self {
         match value {
             LlamaContextType::Default => 0,

--- a/llama-cpp-2/src/context/params/get_set.rs
+++ b/llama-cpp-2/src/context/params/get_set.rs
@@ -211,14 +211,14 @@ impl LlamaContextParams {
     /// models that support it.
     #[must_use]
     pub fn with_ctx_type(mut self, ctx_type: LlamaContextType) -> Self {
-        self.context_params.ctx_type = u32::from(ctx_type);
+        self.context_params.ctx_type = ctx_type as _;
         self
     }
 
     /// Get the context type.
     #[must_use]
     pub fn ctx_type(&self) -> LlamaContextType {
-        LlamaContextType::from(self.context_params.ctx_type)
+        LlamaContextType::from(self.context_params.ctx_type as i32)
     }
 
     /// Set the type of rope scaling

--- a/llama-cpp-2/src/context/params/get_set.rs
+++ b/llama-cpp-2/src/context/params/get_set.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU32;
 
 use super::{
-    KvCacheType, LlamaAttentionType, LlamaContextParams, LlamaPoolingType, RopeScalingType,
+    KvCacheType, LlamaAttentionType, LlamaContextParams, LlamaContextType, LlamaPoolingType,
+    RopeScalingType,
 };
 
 impl LlamaContextParams {
@@ -128,6 +129,22 @@ impl LlamaContextParams {
         self.context_params.n_seq_max
     }
 
+    /// Set the number of recurrent-state snapshots per sequence.
+    ///
+    /// This is used by upstream recurrent-state rollback support and may be
+    /// required by speculative/MTP flows on supported models.
+    #[must_use]
+    pub fn with_n_rs_seq(mut self, n_rs_seq: u32) -> Self {
+        self.context_params.n_rs_seq = n_rs_seq;
+        self
+    }
+
+    /// Get the number of recurrent-state snapshots per sequence.
+    #[must_use]
+    pub fn n_rs_seq(&self) -> u32 {
+        self.context_params.n_rs_seq
+    }
+
     /// Set the number of threads
     ///
     /// # Examples
@@ -186,6 +203,22 @@ impl LlamaContextParams {
     #[must_use]
     pub fn n_threads_batch(&self) -> i32 {
         self.context_params.n_threads_batch
+    }
+
+    /// Set the context type.
+    ///
+    /// `LlamaContextType::Mtp` requests upstream MTP context behavior for
+    /// models that support it.
+    #[must_use]
+    pub fn with_ctx_type(mut self, ctx_type: LlamaContextType) -> Self {
+        self.context_params.ctx_type = u32::from(ctx_type);
+        self
+    }
+
+    /// Get the context type.
+    #[must_use]
+    pub fn ctx_type(&self) -> LlamaContextType {
+        LlamaContextType::from(self.context_params.ctx_type)
     }
 
     /// Set the type of rope scaling

--- a/llama-cpp-2/src/context/params/get_set.rs
+++ b/llama-cpp-2/src/context/params/get_set.rs
@@ -145,6 +145,28 @@ impl LlamaContextParams {
         self.context_params.n_rs_seq
     }
 
+    /// Set the max number of outputs in a ubatch (0 = `n_batch`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use llama_cpp_2::context::params::LlamaContextParams;
+    /// let params = LlamaContextParams::default()
+    ///     .with_n_outputs_max(64);
+    /// assert_eq!(params.n_outputs_max(), 64);
+    /// ```
+    #[must_use]
+    pub fn with_n_outputs_max(mut self, n_outputs_max: u32) -> Self {
+        self.context_params.n_outputs_max = n_outputs_max;
+        self
+    }
+
+    /// Get the max number of outputs in a ubatch (0 = `n_batch`).
+    #[must_use]
+    pub fn n_outputs_max(&self) -> u32 {
+        self.context_params.n_outputs_max
+    }
+
     /// Set the number of threads
     ///
     /// # Examples

--- a/llama-cpp-2/src/context/params/get_set.rs
+++ b/llama-cpp-2/src/context/params/get_set.rs
@@ -243,6 +243,22 @@ impl LlamaContextParams {
         LlamaContextType::from(self.context_params.ctx_type as i32)
     }
 
+    /// Pair the context created from these params with an existing context.
+    ///
+    /// Some drafter architectures cannot run standalone and must be attached to a target
+    /// context at creation time (e.g. Gemma 4 assistant MTP drafters, which cross-attend into
+    /// the target's memory and reuse its output head, or EAGLE3 heads without their own
+    /// embeddings). llama.cpp refuses to create such contexts unless `ctx_other` points at the
+    /// target context.
+    ///
+    /// The caller must keep `other` alive for the entire lifetime of the context created from
+    /// these params; llama.cpp stores the raw pointer and dereferences it during decode.
+    #[must_use]
+    pub fn with_ctx_other(mut self, other: &crate::context::LlamaContext<'_>) -> Self {
+        self.context_params.ctx_other = other.context.as_ptr();
+        self
+    }
+
     /// Set the type of rope scaling
     ///
     /// # Examples

--- a/llama-cpp-2/src/llama_batch.rs
+++ b/llama-cpp-2/src/llama_batch.rs
@@ -2,13 +2,20 @@
 
 use crate::token::LlamaToken;
 use llama_cpp_sys_2::{llama_batch, llama_batch_free, llama_batch_init, llama_pos, llama_seq_id};
+use std::ffi::c_void;
 use std::marker::PhantomData;
+
+unsafe extern "C" {
+    fn malloc(size: usize) -> *mut c_void;
+}
 
 /// A safe wrapper around `llama_batch`.
 #[derive(Debug)]
 pub struct LlamaBatch<'a> {
     /// The number of tokens the batch was allocated with. they are safe to write to - but not necessarily read from as they are not necessarily initialized
     allocated: usize,
+    /// The embedding width allocated for this batch. Zero means token-only.
+    n_embd: usize,
     /// The logits that are initialized. Used by [`LlamaContext`] to ensure that only initialized logits are accessed.
     pub(crate) initialized_logits: Vec<i32>,
     #[allow(clippy::doc_markdown)]
@@ -26,6 +33,12 @@ pub enum BatchAddError {
     /// Empty buffer is provided for [`LlamaBatch::get_one`]
     #[error("Empty buffer")]
     EmptyBuffer,
+    /// The batch was created without embedding storage.
+    #[error("Batch does not have embedding storage")]
+    EmbeddingsDisabled,
+    /// The provided embedding row length does not match the batch embedding width.
+    #[error("Embedding length mismatch: expected {expected}, got {actual}")]
+    EmbeddingLengthMismatch { expected: usize, actual: usize },
 }
 
 impl<'a> LlamaBatch<'a> {
@@ -97,6 +110,49 @@ impl<'a> LlamaBatch<'a> {
         Ok(())
     }
 
+    /// Add a token plus embedding row to the batch for MTP-style mixed-token inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is insufficient space in the buffer, if the batch was not
+    /// created with embedding storage, or if the embedding width does not match.
+    pub fn add_with_embedding(
+        &mut self,
+        token: LlamaToken,
+        embedding: &[f32],
+        pos: llama_pos,
+        seq_ids: &[i32],
+        logits: bool,
+    ) -> Result<(), BatchAddError> {
+        if self.n_embd == 0 || self.llama_batch.embd.is_null() {
+            return Err(BatchAddError::EmbeddingsDisabled);
+        }
+        if embedding.len() != self.n_embd {
+            return Err(BatchAddError::EmbeddingLengthMismatch {
+                expected: self.n_embd,
+                actual: embedding.len(),
+            });
+        }
+
+        self.add(token, pos, seq_ids, logits)?;
+
+        let offset = usize::try_from(self.llama_batch.n_tokens - 1)
+            .expect("cannot fit n_tokens into a usize");
+        let embd_offset = offset
+            .checked_mul(self.n_embd)
+            .expect("embedding offset overflow");
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                embedding.as_ptr(),
+                self.llama_batch.embd.add(embd_offset),
+                self.n_embd,
+            );
+        }
+
+        Ok(())
+    }
+
     /// Add a sequence of tokens to the batch for the given sequence id. If `logits_all` is true, the
     /// tokens will be initialized and can be read from after the next decode.
     ///
@@ -150,6 +206,35 @@ impl<'a> LlamaBatch<'a> {
 
         LlamaBatch {
             allocated: n_tokens,
+            n_embd: 0,
+            initialized_logits: vec![],
+            llama_batch: batch,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create a new `LlamaBatch` with storage for both tokens and embedding rows.
+    #[must_use]
+    pub fn new_with_embeddings(n_tokens: usize, n_embd: usize, n_seq_max: i32) -> Self {
+        let n_tokens_i32 = i32::try_from(n_tokens).expect("cannot fit n_tokens into a i32");
+        let n_embd_i32 = i32::try_from(n_embd).expect("cannot fit n_embd into a i32");
+        let mut batch = unsafe { llama_batch_init(n_tokens_i32, n_embd_i32, n_seq_max) };
+
+        if batch.token.is_null() {
+            let bytes = std::mem::size_of::<llama_cpp_sys_2::llama_token>()
+                .checked_mul(n_tokens)
+                .expect("token allocation overflow");
+            let ptr = unsafe { malloc(bytes) } as *mut llama_cpp_sys_2::llama_token;
+            assert!(
+                !ptr.is_null(),
+                "failed to allocate token storage for embedding batch"
+            );
+            batch.token = ptr;
+        }
+
+        LlamaBatch {
+            allocated: n_tokens,
+            n_embd,
             initialized_logits: vec![],
             llama_batch: batch,
             phantom: PhantomData,
@@ -182,6 +267,7 @@ impl<'a> LlamaBatch<'a> {
         };
         let batch = Self {
             allocated: 0,
+            n_embd: 0,
             initialized_logits: vec![(tokens.len() - 1)
                 .try_into()
                 .expect("number of tokens exceeds i32::MAX + 1")],

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -638,6 +638,17 @@ impl LlamaModel {
         unsafe { llama_cpp_sys_2::llama_n_embd(self.model.as_ptr()) }
     }
 
+    /// Get the output embedding width of the model.
+    ///
+    /// For most models this equals [`Self::n_embd`]. Drafter models that project their hidden
+    /// state into a wider target space (e.g. Gemma 4 assistant MTP drafters, which advertise
+    /// `embedding_length_out`) report the projected width here. Speculative drivers should
+    /// validate this against the target model's [`Self::n_embd`].
+    #[must_use]
+    pub fn n_embd_out(&self) -> c_int {
+        unsafe { llama_cpp_sys_2::llama_model_n_embd_out(self.model.as_ptr()) }
+    }
+
     /// Returns the total size of all the tensors in the model in bytes.
     pub fn size(&self) -> u64 {
         unsafe { llama_cpp_sys_2::llama_model_size(self.model.as_ptr()) }

--- a/llama-cpp-2/src/model/params.rs
+++ b/llama-cpp-2/src/model/params.rs
@@ -353,7 +353,7 @@ impl LlamaModelParams {
         self.params.tensor_buft_overrides = null();
 
         let status = unsafe {
-            llama_cpp_sys_2::llama_params_fit(
+            llama_cpp_sys_2::llama_rs_params_fit(
                 model_path.as_ptr(),
                 &raw mut self.params,
                 &raw mut cparams.context_params,
@@ -366,8 +366,10 @@ impl LlamaModelParams {
         };
 
         match status {
-            llama_cpp_sys_2::LLAMA_PARAMS_FIT_STATUS_SUCCESS => {}
-            llama_cpp_sys_2::LLAMA_PARAMS_FIT_STATUS_FAILURE => return Err(FitError::Failure),
+            llama_cpp_sys_2::LLAMA_RS_PARAMS_FIT_STATUS_SUCCESS => {}
+            llama_cpp_sys_2::LLAMA_RS_PARAMS_FIT_STATUS_FAILURE => {
+                return Err(FitError::Failure)
+            }
             _ => return Err(FitError::Error),
         }
 

--- a/llama-cpp-2/src/model/params.rs
+++ b/llama-cpp-2/src/model/params.rs
@@ -367,9 +367,7 @@ impl LlamaModelParams {
 
         match status {
             llama_cpp_sys_2::LLAMA_RS_PARAMS_FIT_STATUS_SUCCESS => {}
-            llama_cpp_sys_2::LLAMA_RS_PARAMS_FIT_STATUS_FAILURE => {
-                return Err(FitError::Failure)
-            }
+            llama_cpp_sys_2::LLAMA_RS_PARAMS_FIT_STATUS_FAILURE => return Err(FitError::Failure),
             _ => return Err(FitError::Error),
         }
 

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -346,6 +346,10 @@ impl Drop for MtmdContext {
 #[derive(Debug, Clone)]
 pub struct MtmdBitmap {
     pub(crate) bitmap: NonNull<llama_cpp_sys_2::mtmd_bitmap>,
+    /// Video decoding context backing a lazy (video) bitmap, if any.
+    /// Only ever set when llama.cpp is built with video support (`MTMD_VIDEO`);
+    /// it must outlive the bitmap and be freed after it.
+    pub(crate) video_ctx: Option<NonNull<llama_cpp_sys_2::mtmd_helper_video>>,
 }
 
 // MtmdBitmap is thread safe
@@ -390,7 +394,10 @@ impl MtmdBitmap {
         let bitmap = unsafe { llama_cpp_sys_2::mtmd_bitmap_init(nx, ny, data.as_ptr()) };
 
         let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
-        Ok(Self { bitmap })
+        Ok(Self {
+            bitmap,
+            video_ctx: None,
+        })
     }
 
     /// Create a bitmap from audio data in PCM F32 format.
@@ -425,7 +432,10 @@ impl MtmdBitmap {
             unsafe { llama_cpp_sys_2::mtmd_bitmap_init_from_audio(data.len(), data.as_ptr()) };
 
         let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
-        Ok(Self { bitmap })
+        Ok(Self {
+            bitmap,
+            video_ctx: None,
+        })
     }
 
     /// Create a bitmap from a file.
@@ -453,15 +463,19 @@ impl MtmdBitmap {
     /// This function is thread-safe.
     pub fn from_file(ctx: &MtmdContext, path: &str) -> Result<Self, MtmdBitmapError> {
         let path_cstr = CString::new(path)?;
-        let bitmap = unsafe {
+        let wrapper = unsafe {
             llama_cpp_sys_2::mtmd_helper_bitmap_init_from_file(
                 ctx.context.as_ptr(),
                 path_cstr.as_ptr(),
+                false,
             )
         };
 
-        let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
-        Ok(Self { bitmap })
+        let bitmap = NonNull::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        Ok(Self {
+            bitmap,
+            video_ctx: NonNull::new(wrapper.video_ctx),
+        })
     }
 
     /// Create a bitmap from a buffer containing file data.
@@ -487,16 +501,20 @@ impl MtmdBitmap {
     ///
     /// This function is thread-safe.
     pub fn from_buffer(ctx: &MtmdContext, data: &[u8]) -> Result<Self, MtmdBitmapError> {
-        let bitmap = unsafe {
+        let wrapper = unsafe {
             llama_cpp_sys_2::mtmd_helper_bitmap_init_from_buf(
                 ctx.context.as_ptr(),
                 data.as_ptr(),
                 data.len(),
+                false,
             )
         };
 
-        let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
-        Ok(Self { bitmap })
+        let bitmap = NonNull::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        Ok(Self {
+            bitmap,
+            video_ctx: NonNull::new(wrapper.video_ctx),
+        })
     }
 
     /// Get bitmap width in pixels.
@@ -580,6 +598,9 @@ impl MtmdBitmap {
 impl Drop for MtmdBitmap {
     fn drop(&mut self) {
         unsafe { llama_cpp_sys_2::mtmd_bitmap_free(self.bitmap.as_ptr()) }
+        if let Some(video_ctx) = self.video_ctx {
+            unsafe { llama_cpp_sys_2::mtmd_helper_video_free(video_ctx.as_ptr()) }
+        }
     }
 }
 

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -37,6 +37,8 @@ include = [
     "/llama.cpp/tools/mtmd/debug/*.cpp",
 
     "/llama.cpp/convert_hf_to_gguf.py", # Yes, it's required
+    "/llama.cpp/conversion/**/*.py",
+    "/llama.cpp/gguf-py/**/*.py",
     "/llama.cpp/common/build-info.cpp.in",
 
     "/llama.cpp/ggml/src/ggml-cuda.cu",

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -558,8 +558,12 @@ fn main() {
     config.define("LLAMA_BUILD_EXAMPLES", "OFF");
     config.define("LLAMA_BUILD_SERVER", "OFF");
     config.define("LLAMA_BUILD_TOOLS", "OFF");
+    config.define("LLAMA_BUILD_APP", "OFF");
+    config.define("LLAMA_BUILD_UI", "OFF");
     config.define("LLAMA_BUILD_COMMON", "ON");
-    config.define("LLAMA_CURL", "OFF");
+    // The common lib uses a vendored cpp-httplib for model downloads; keep it
+    // free of a system OpenSSL dependency (downloads then fall back to HTTP-only).
+    config.define("LLAMA_OPENSSL", "OFF");
     config.define("GGML_CCACHE", "OFF");
 
     // Pass CMAKE_ environment variables down to CMake
@@ -1059,6 +1063,17 @@ fn main() {
         let common_profile_dir = common_lib_dir.join(&profile);
         if common_profile_dir.is_dir() {
             common_lib_dirs.push(common_profile_dir);
+        }
+
+        // The common lib depends on the vendored cpp-httplib static lib,
+        // which is built in the vendor directory and not installed.
+        let httplib_dir = out_dir.join("build").join("vendor").join("cpp-httplib");
+        if httplib_dir.is_dir() {
+            common_lib_dirs.push(httplib_dir.clone());
+            let httplib_profile_dir = httplib_dir.join(&profile);
+            if httplib_profile_dir.is_dir() {
+                common_lib_dirs.push(httplib_profile_dir);
+            }
         }
 
         let mut common_libs = Vec::new();

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -149,6 +149,31 @@ fn extract_lib_assets(out_dir: &Path, target_os: &TargetOs) -> Vec<PathBuf> {
     files
 }
 
+fn extract_static_lib_names(dir: &Path, target_os: &TargetOs) -> Vec<String> {
+    let pattern = match target_os {
+        TargetOs::Windows(_) => "*.lib",
+        _ => "*.a",
+    };
+
+    let mut lib_names = Vec::new();
+    let pattern = dir.join(pattern);
+    for entry in glob(pattern.to_str().unwrap()).unwrap() {
+        match entry {
+            Ok(path) => {
+                let stem = path.file_stem().unwrap();
+                let stem_str = stem.to_str().unwrap();
+                let lib_name = stem_str.strip_prefix("lib").unwrap_or(stem_str);
+                lib_names.push(lib_name.to_string());
+            }
+            Err(e) => println!("cargo:warning=error={}", e),
+        }
+    }
+
+    lib_names.sort();
+    lib_names.dedup();
+    lib_names
+}
+
 fn macos_link_search_path() -> Option<String> {
     let output = Command::new("clang")
         .arg("--print-search-dirs")
@@ -535,6 +560,7 @@ fn main() {
     config.define("LLAMA_BUILD_TOOLS", "OFF");
     config.define("LLAMA_BUILD_COMMON", "ON");
     config.define("LLAMA_CURL", "OFF");
+    config.define("GGML_CCACHE", "OFF");
 
     // Pass CMAKE_ environment variables down to CMake
     for (key, value) in env::vars() {
@@ -1029,18 +1055,27 @@ fn main() {
 
     let common_lib_dir = out_dir.join("build").join("common");
     if common_lib_dir.is_dir() {
-        println!(
-            "cargo:rustc-link-search=native={}",
-            common_lib_dir.display()
-        );
+        let mut common_lib_dirs = vec![common_lib_dir.clone()];
         let common_profile_dir = common_lib_dir.join(&profile);
         if common_profile_dir.is_dir() {
-            println!(
-                "cargo:rustc-link-search=native={}",
-                common_profile_dir.display()
-            );
+            common_lib_dirs.push(common_profile_dir);
         }
-        println!("cargo:rustc-link-lib=static=common");
+
+        let mut common_libs = Vec::new();
+        for dir in &common_lib_dirs {
+            println!("cargo:rustc-link-search=native={}", dir.display());
+            common_libs.extend(extract_static_lib_names(dir, &target_os));
+        }
+
+        if common_libs.is_empty() {
+            println!("cargo:rustc-link-lib=static=common");
+        } else {
+            common_libs.sort();
+            common_libs.dedup();
+            for lib in common_libs {
+                println!("cargo:rustc-link-lib=static={lib}");
+            }
+        }
     }
 
     if cfg!(feature = "system-ggml") {

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -225,6 +225,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LLAMA_LIB_PROFILE");
     println!("cargo:rerun-if-env-changed=LLAMA_BUILD_SHARED_LIBS");
     println!("cargo:rerun-if-env-changed=LLAMA_STATIC_CRT");
+    println!("cargo:rerun-if-env-changed=LLAMA_CUDA_DISABLE_NCCL");
 
     debug_log!("TARGET: {}", target_triple);
     debug_log!("CARGO_MANIFEST_DIR: {}", manifest_dir);
@@ -797,6 +798,18 @@ fn main() {
 
     if cfg!(feature = "cuda") {
         config.define("GGML_CUDA", "ON");
+
+        // llama.cpp enables GGML_CUDA_NCCL by default and may auto-detect NCCL via
+        // find_package(NCCL). Downstream Rust linking then fails because this crate
+        // does not explicitly link libnccl. Disable NCCL by default unless the
+        // caller opts back in with LLAMA_CUDA_DISABLE_NCCL=0.
+        let disable_nccl = env::var("LLAMA_CUDA_DISABLE_NCCL")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+        if disable_nccl {
+            config.define("CMAKE_DISABLE_FIND_PACKAGE_NCCL", "TRUE");
+            config.define("GGML_CUDA_NCCL", "OFF");
+        }
 
         if cfg!(feature = "cuda-no-vmm") {
             config.define("GGML_CUDA_NO_VMM", "ON");

--- a/llama-cpp-sys-2/wrapper_common.cpp
+++ b/llama-cpp-sys-2/wrapper_common.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <stdint.h>
 
+#include "llama.cpp/common/fit.h"
 #include "llama.cpp/common/json-schema-to-grammar.h"
 #include "llama.cpp/include/llama.h"
 #include "wrapper_utils.h"
@@ -165,4 +166,43 @@ extern "C" llama_rs_status llama_rs_sampler_accept(struct llama_sampler * sample
     } catch (...) {
         return LLAMA_RS_STATUS_EXCEPTION;
     }
+}
+
+extern "C" enum llama_rs_params_fit_status llama_rs_params_fit(
+    const char * path_model,
+    struct llama_model_params * mparams,
+    struct llama_context_params * cparams,
+    float * tensor_split,
+    struct llama_model_tensor_buft_override * tensor_buft_overrides,
+    size_t * margins,
+    uint32_t n_ctx_min,
+    enum ggml_log_level log_level) {
+    if (!path_model || !mparams || !cparams || !margins) {
+        return LLAMA_RS_PARAMS_FIT_STATUS_ERROR;
+    }
+
+    switch (common_fit_params(
+        path_model,
+        mparams,
+        cparams,
+        tensor_split,
+        tensor_buft_overrides,
+        margins,
+        n_ctx_min,
+        log_level)) {
+        case COMMON_PARAMS_FIT_STATUS_SUCCESS:
+            return LLAMA_RS_PARAMS_FIT_STATUS_SUCCESS;
+        case COMMON_PARAMS_FIT_STATUS_FAILURE:
+            return LLAMA_RS_PARAMS_FIT_STATUS_FAILURE;
+        case COMMON_PARAMS_FIT_STATUS_ERROR:
+        default:
+            return LLAMA_RS_PARAMS_FIT_STATUS_ERROR;
+    }
+}
+
+extern "C" void llama_rs_memory_breakdown_print(const struct llama_context * ctx) {
+    if (!ctx) {
+        return;
+    }
+    common_memory_breakdown_print(ctx);
 }

--- a/llama-cpp-sys-2/wrapper_common.cpp
+++ b/llama-cpp-sys-2/wrapper_common.cpp
@@ -208,23 +208,23 @@ extern "C" void llama_rs_memory_breakdown_print(const struct llama_context * ctx
     common_memory_breakdown_print(ctx);
 }
 
-extern "C" void llama_rs_set_embeddings_pre_norm(struct llama_context * ctx, bool value) {
+extern "C" void llama_rs_set_embeddings_nextn(struct llama_context * ctx, bool value, bool masked) {
     if (!ctx) {
         return;
     }
-    llama_set_embeddings_pre_norm(ctx, value);
+    llama_set_embeddings_nextn(ctx, value, masked);
 }
 
-extern "C" float * llama_rs_get_embeddings_pre_norm(struct llama_context * ctx) {
+extern "C" float * llama_rs_get_embeddings_nextn(struct llama_context * ctx) {
     if (!ctx) {
         return nullptr;
     }
-    return llama_get_embeddings_pre_norm(ctx);
+    return llama_get_embeddings_nextn(ctx);
 }
 
-extern "C" float * llama_rs_get_embeddings_pre_norm_ith(struct llama_context * ctx, int32_t i) {
+extern "C" float * llama_rs_get_embeddings_nextn_ith(struct llama_context * ctx, int32_t i) {
     if (!ctx) {
         return nullptr;
     }
-    return llama_get_embeddings_pre_norm_ith(ctx, i);
+    return llama_get_embeddings_nextn_ith(ctx, i);
 }

--- a/llama-cpp-sys-2/wrapper_common.cpp
+++ b/llama-cpp-sys-2/wrapper_common.cpp
@@ -9,6 +9,7 @@
 #include "llama.cpp/common/fit.h"
 #include "llama.cpp/common/json-schema-to-grammar.h"
 #include "llama.cpp/include/llama.h"
+#include "llama.cpp/src/llama-ext.h"
 #include "wrapper_utils.h"
 
 #include <nlohmann/json.hpp>
@@ -205,4 +206,25 @@ extern "C" void llama_rs_memory_breakdown_print(const struct llama_context * ctx
         return;
     }
     common_memory_breakdown_print(ctx);
+}
+
+extern "C" void llama_rs_set_embeddings_pre_norm(struct llama_context * ctx, bool value) {
+    if (!ctx) {
+        return;
+    }
+    llama_set_embeddings_pre_norm(ctx, value);
+}
+
+extern "C" float * llama_rs_get_embeddings_pre_norm(struct llama_context * ctx) {
+    if (!ctx) {
+        return nullptr;
+    }
+    return llama_get_embeddings_pre_norm(ctx);
+}
+
+extern "C" float * llama_rs_get_embeddings_pre_norm_ith(struct llama_context * ctx, int32_t i) {
+    if (!ctx) {
+        return nullptr;
+    }
+    return llama_get_embeddings_pre_norm_ith(ctx, i);
 }

--- a/llama-cpp-sys-2/wrapper_common.h
+++ b/llama-cpp-sys-2/wrapper_common.h
@@ -84,6 +84,12 @@ enum llama_rs_params_fit_status llama_rs_params_fit(
 
 void llama_rs_memory_breakdown_print(const struct llama_context * ctx);
 
+void llama_rs_set_embeddings_pre_norm(struct llama_context * ctx, bool value);
+
+float * llama_rs_get_embeddings_pre_norm(struct llama_context * ctx);
+
+float * llama_rs_get_embeddings_pre_norm_ith(struct llama_context * ctx, int32_t i);
+
 void llama_rs_chat_template_result_free(struct llama_rs_chat_template_result * result);
 void llama_rs_string_free(char * ptr);
 

--- a/llama-cpp-sys-2/wrapper_common.h
+++ b/llama-cpp-sys-2/wrapper_common.h
@@ -30,6 +30,12 @@ struct llama_rs_chat_template_result {
     size_t additional_stops_count;
 };
 
+enum llama_rs_params_fit_status {
+    LLAMA_RS_PARAMS_FIT_STATUS_SUCCESS = 0,
+    LLAMA_RS_PARAMS_FIT_STATUS_FAILURE = 1,
+    LLAMA_RS_PARAMS_FIT_STATUS_ERROR = 2,
+};
+
 #include "wrapper_utils.h"
 
 #ifdef __cplusplus
@@ -65,6 +71,18 @@ struct llama_sampler * llama_rs_sampler_init_grammar_lazy_patterns(
     size_t num_trigger_tokens);
 
 llama_rs_status llama_rs_sampler_accept(struct llama_sampler * sampler, llama_token token);
+
+enum llama_rs_params_fit_status llama_rs_params_fit(
+    const char * path_model,
+    struct llama_model_params * mparams,
+    struct llama_context_params * cparams,
+    float * tensor_split,
+    struct llama_model_tensor_buft_override * tensor_buft_overrides,
+    size_t * margins,
+    uint32_t n_ctx_min,
+    enum ggml_log_level log_level);
+
+void llama_rs_memory_breakdown_print(const struct llama_context * ctx);
 
 void llama_rs_chat_template_result_free(struct llama_rs_chat_template_result * result);
 void llama_rs_string_free(char * ptr);

--- a/llama-cpp-sys-2/wrapper_common.h
+++ b/llama-cpp-sys-2/wrapper_common.h
@@ -84,11 +84,11 @@ enum llama_rs_params_fit_status llama_rs_params_fit(
 
 void llama_rs_memory_breakdown_print(const struct llama_context * ctx);
 
-void llama_rs_set_embeddings_pre_norm(struct llama_context * ctx, bool value);
+void llama_rs_set_embeddings_nextn(struct llama_context * ctx, bool value, bool masked);
 
-float * llama_rs_get_embeddings_pre_norm(struct llama_context * ctx);
+float * llama_rs_get_embeddings_nextn(struct llama_context * ctx);
 
-float * llama_rs_get_embeddings_pre_norm_ith(struct llama_context * ctx, int32_t i);
+float * llama_rs_get_embeddings_nextn_ith(struct llama_context * ctx, int32_t i);
 
 void llama_rs_chat_template_result_free(struct llama_rs_chat_template_result * result);
 void llama_rs_string_free(char * ptr);

--- a/llama-cpp-sys-2/wrapper_oai.cpp
+++ b/llama-cpp-sys-2/wrapper_oai.cpp
@@ -49,18 +49,6 @@ static std::string random_string(size_t length = 32) {
     return result;
 }
 
-static bool ends_with(const std::string & value, const std::string & suffix) {
-    return value.size() >= suffix.size()
-        && value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
-static bool detect_thinking_forced_open(const common_chat_params & params) {
-    return params.supports_thinking
-        && !params.thinking_start_tag.empty()
-        && !params.thinking_end_tag.empty()
-        && ends_with(params.generation_prompt, params.thinking_start_tag);
-}
-
 static void init_chat_msg(struct llama_rs_chat_msg_oaicompat * out_msg) {
     if (!out_msg) {
         return;
@@ -854,8 +842,35 @@ extern "C" llama_rs_status llama_rs_chat_msg_diff_to_oaicompat_json(
             msg_diff.tool_call_delta.id =
                 diff->tool_call_delta.id ? diff->tool_call_delta.id : "";
         }
-        auto json_delta = common_chat_msg_diff_to_json_oaicompat(msg_diff).dump();
-        *out_json = llama_rs_dup_string(json_delta);
+        json json_delta = json::object();
+        if (!msg_diff.reasoning_content_delta.empty()) {
+            json_delta["reasoning_content"] = msg_diff.reasoning_content_delta;
+        }
+        if (!msg_diff.content_delta.empty()) {
+            json_delta["content"] = msg_diff.content_delta;
+        }
+        if (msg_diff.tool_call_index != std::string::npos) {
+            json tool_call = json::object();
+            tool_call["index"] = msg_diff.tool_call_index;
+            if (!msg_diff.tool_call_delta.id.empty()) {
+                tool_call["id"] = msg_diff.tool_call_delta.id;
+                tool_call["type"] = "function";
+            }
+            if (!msg_diff.tool_call_delta.name.empty()
+                || !msg_diff.tool_call_delta.arguments.empty()) {
+                json function = json::object();
+                if (!msg_diff.tool_call_delta.name.empty()) {
+                    function["name"] = msg_diff.tool_call_delta.name;
+                }
+                if (!msg_diff.tool_call_delta.arguments.empty()) {
+                    function["arguments"] = msg_diff.tool_call_delta.arguments;
+                }
+                tool_call["function"] = std::move(function);
+            }
+            json_delta["tool_calls"] = json::array({ std::move(tool_call) });
+        }
+        auto json_delta_str = json_delta.dump();
+        *out_json = llama_rs_dup_string(json_delta_str);
         return *out_json ? LLAMA_RS_STATUS_OK : LLAMA_RS_STATUS_ALLOCATION_FAILED;
     } catch (const std::exception &) {
         return LLAMA_RS_STATUS_EXCEPTION;


### PR DESCRIPTION
## What this fixes

Some Linux CUDA builds were failing at link time on systems that had NCCL installed.

The errors looked like this:

```text
rust-lld: error: undefined symbol: ncclCommInitAll
rust-lld: error: undefined symbol: ncclGetErrorString
rust-lld: error: undefined symbol: ncclGroupStart
rust-lld: error: undefined symbol: ncclAllReduce
rust-lld: error: undefined symbol: ncclGroupEnd
collect2: error: ld returned 1 exit status
error: could not compile due to 1 previous error
```

The root cause was that `llama.cpp` could detect NCCL automatically during the CMake build, but `llama-cpp-sys-2` was not linking `libnccl` on the Rust side. That left us with compiled CUDA objects that referenced NCCL symbols but no final NCCL linkage.

## What changed

This update disables NCCL autodetection by default in CUDA builds by setting the relevant CMake flags in `llama-cpp-sys-2/build.rs`.

If someone does want NCCL enabled, they can still opt back in with:

```bash
LLAMA_CUDA_DISABLE_NCCL=0
```

## Why this approach

NCCL is mainly useful for multi-GPU collective operations. For normal single-GPU setups, auto-enabling it is unnecessary and makes builds more fragile on machines where NCCL happens to be installed.

This keeps the default CUDA build path reliable while still leaving a deliberate opt-in path for NCCL.

## Notes

If a previous build already cached NCCL detection, a clean rebuild may be needed.

Co-authored-by: Lothar Hoffmann