### PR TITLE
feat(llama-cpp-sys): add openssl Cargo feature (default on) to gate LLAMA_OPENSSL

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/utilityai/llama-cpp-rs"
 
 [dependencies]
 enumflags2 = "0.7.12"
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.146" }
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.146", default-features = false }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
@@ -25,7 +25,7 @@ serde_json = "1.0"
 tracing-subscriber = { workspace = true }
 
 [features]
-default = ["openmp", "android-shared-stdcxx"]
+default = ["openmp", "android-shared-stdcxx", "openssl"]
 cuda = ["llama-cpp-sys-2/cuda"]
 cuda-no-vmm = ["cuda", "llama-cpp-sys-2/cuda-no-vmm"]
 metal = ["llama-cpp-sys-2/metal"]
@@ -42,10 +42,11 @@ system-ggml = ["llama-cpp-sys-2/system-ggml"]
 system-ggml-static = ["llama-cpp-sys-2/system-ggml-static"]
 llguidance = ["dep:llguidance", "dep:toktrie"]
 dynamic-backends = ["llama-cpp-sys-2/dynamic-backends"]
+openssl = ["llama-cpp-sys-2/openssl"]
 
 
 [target.'cfg(all(target_os = "macos", any(target_arch = "aarch64", target_arch = "arm64")))'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.146", features = [
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.146", default-features = false, features = [
     "metal",
 ] }
 

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -82,6 +82,7 @@ glob = "0.3.3"
 walkdir = "2"
 
 [features]
+default = ["openssl"]
 cuda = []
 # Disables the need to dynamically link against libcuda.so / cuda.dll
 cuda-no-vmm = ["cuda"]
@@ -97,3 +98,7 @@ system-ggml = []
 system-ggml-static = ["system-ggml"]
 mtmd = []
 dynamic-backends = ["dynamic-link"]
+# Enables HTTPS in vendored cpp-httplib (links against system OpenSSL).
+# Default-on for backwards compatibility with upstream llama.cpp's
+# LLAMA_OPENSSL=ON default. Disable to omit OpenSSL linkage entirely.
+openssl = []

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -535,6 +535,15 @@ fn main() {
     config.define("LLAMA_BUILD_COMMON", "ON");
     config.define("LLAMA_CURL", "OFF");
 
+    // Gate cpp-httplib's HTTPS support on the `openssl` Cargo feature
+    // (default ON to preserve backwards-compatible behavior with upstream
+    // llama.cpp's default of LLAMA_OPENSSL=ON). Downstream consumers that
+    // do not call cpp-httplib's HTTP client can disable this feature to
+    // drop the OpenSSL link dependency entirely.
+    if !cfg!(feature = "openssl") {
+        config.define("LLAMA_OPENSSL", "OFF");
+    }
+
     // Pass CMAKE_ environment variables down to CMake
     for (key, value) in env::vars() {
         if key.starts_with("CMAKE_") {


### PR DESCRIPTION
## Summary

Adds a new `openssl` Cargo feature to `llama-cpp-sys-2` (and a pass-through on `llama-cpp-2`) that gates the `LLAMA_OPENSSL` CMake define. The feature defaults to ON, so existing consumers see no behavior change. Downstream consumers that do not use cpp-httplib's HTTPS client can pass `default-features = false` (optionally re-enabling other features) to drop the OpenSSL link dependency entirely.

## Motivation

llama.cpp's `LLAMA_BUILD_COMMON=ON` (set by this crate's build.rs) unconditionally pulls in `vendor/cpp-httplib`, whose CMake config in turn calls `find_package(OpenSSL)` when `LLAMA_OPENSSL=ON` (upstream's default). On macOS this typically resolves to Homebrew's `openssl@3`, baking `/opt/homebrew/...libssl.3.dylib` and `libcrypto.3.dylib` into `LC_LOAD_DYLIB` of the final binary. Consumers who never call cpp-httplib (e.g. Rust apps doing HTTPS via `reqwest`+`rustls`) inherit a vestigial Homebrew dynamic-library dependency that breaks at runtime if the user's openssl@3 install is missing or rolled forward.

There is currently no way to disable `LLAMA_OPENSSL` from a downstream `Cargo.toml` — the env-var passthrough loop in `build.rs` only forwards `CMAKE_*`-prefixed variables. The full design rationale (with `otool -L` evidence) is at https://github.com/dbyton/conductor/blob/main/docs/specs/2026-05-06-decouple-app-from-homebrew-openssl-design.md.

## Changes

- `llama-cpp-sys-2/build.rs`: emit `config.define("LLAMA_OPENSSL", "OFF")` only when `feature = "openssl"` is disabled. With the feature on (default), upstream llama.cpp's own default fires unchanged.
- `llama-cpp-sys-2/Cargo.toml`: add `openssl = []` feature; set `default = ["openssl"]`.
- `llama-cpp-2/Cargo.toml`: add `openssl = ["llama-cpp-sys-2/openssl"]` pass-through; set `default-features = false` on the sys path dep (both the regular dep block and the macOS-aarch64 target-specific block) and add `openssl` to the wrapper's `default`.

## Backwards compatibility

Default-on. `cargo build` with no feature flags produces an identical CMake invocation to today. Verified locally with `cargo check` on both crates with default and `--no-default-features` feature sets.

## Test plan

- [x] `cargo check -p llama-cpp-sys-2` (default → openssl ON, matches current behavior)
- [x] `cargo check -p llama-cpp-sys-2 --no-default-features`
- [x] `cargo check -p llama-cpp-2`
- [x] `cargo check -p llama-cpp-2 --no-default-features --features metal`