### PR TITLE
Add MTP speculative decoding support

### DIFF
--- a/llama-cpp-2/src/context/params.rs
+++ b/llama-cpp-2/src/context/params.rs
@@ -122,6 +122,37 @@ impl From<LlamaAttentionType> for i32 {
     }
 }
 
+/// A rusty wrapper around `llama_context_type`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LlamaContextType {
+    /// Default decoder context.
+    Default,
+    /// Multi-token-prediction draft context.
+    Mtp,
+    /// Unknown context type from a newer llama.cpp.
+    Unknown(llama_cpp_sys_2::llama_context_type),
+}
+
+impl From<llama_cpp_sys_2::llama_context_type> for LlamaContextType {
+    fn from(value: llama_cpp_sys_2::llama_context_type) -> Self {
+        match value {
+            x if x == llama_cpp_sys_2::LLAMA_CONTEXT_TYPE_DEFAULT => Self::Default,
+            x if x == llama_cpp_sys_2::LLAMA_CONTEXT_TYPE_MTP => Self::Mtp,
+            x => Self::Unknown(x),
+        }
+    }
+}
+
+impl From<LlamaContextType> for llama_cpp_sys_2::llama_context_type {
+    fn from(value: LlamaContextType) -> Self {
+        match value {
+            LlamaContextType::Default => llama_cpp_sys_2::LLAMA_CONTEXT_TYPE_DEFAULT,
+            LlamaContextType::Mtp => llama_cpp_sys_2::LLAMA_CONTEXT_TYPE_MTP,
+            LlamaContextType::Unknown(raw) => raw,
+        }
+    }
+}
+
 /// A rusty wrapper around `ggml_type` for KV cache types.
 #[allow(non_camel_case_types, missing_docs)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/llama-cpp-2/src/context/params/get_set.rs
+++ b/llama-cpp-2/src/context/params/get_set.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU32;
 
 use super::{
-    KvCacheType, LlamaAttentionType, LlamaContextParams, LlamaPoolingType, RopeScalingType,
+    KvCacheType, LlamaAttentionType, LlamaContextParams, LlamaContextType, LlamaPoolingType,
+    RopeScalingType,
 };
 
 impl LlamaContextParams {
@@ -126,6 +127,35 @@ impl LlamaContextParams {
     #[must_use]
     pub fn n_seq_max(&self) -> u32 {
         self.context_params.n_seq_max
+    }
+
+    /// Set the number of recurrent-state rollback snapshots per sequence.
+    ///
+    /// MTP speculative decoding uses this on the target context so llama.cpp can
+    /// roll recurrent state back after partially accepted drafts.
+    #[must_use]
+    pub fn with_n_rs_seq(mut self, n_rs_seq: u32) -> Self {
+        self.context_params.n_rs_seq = n_rs_seq;
+        self
+    }
+
+    /// Get the number of recurrent-state rollback snapshots per sequence.
+    #[must_use]
+    pub fn n_rs_seq(&self) -> u32 {
+        self.context_params.n_rs_seq
+    }
+
+    /// Set the llama.cpp context type.
+    #[must_use]
+    pub fn with_context_type(mut self, context_type: LlamaContextType) -> Self {
+        self.context_params.ctx_type = context_type.into();
+        self
+    }
+
+    /// Get the llama.cpp context type.
+    #[must_use]
+    pub fn context_type(&self) -> LlamaContextType {
+        self.context_params.ctx_type.into()
     }
 
     /// Set the number of threads

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -34,6 +34,8 @@ pub mod model;
 #[cfg(feature = "mtmd")]
 pub mod mtmd;
 pub mod sampling;
+#[cfg(feature = "common")]
+pub mod speculative;
 pub mod timing;
 pub mod token;
 pub mod token_type;

--- a/llama-cpp-2/src/speculative.rs
+++ b/llama-cpp-2/src/speculative.rs
@@ -1,0 +1,218 @@
+//! Experimental wrappers for llama.cpp speculative decoding helpers.
+
+use std::ptr::NonNull;
+
+use crate::context::LlamaContext;
+use crate::llama_batch::LlamaBatch;
+use crate::status_is_ok;
+use crate::token::LlamaToken;
+
+/// Parameters for same-model MTP speculative decoding.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MtpSpeculativeParams {
+    /// Maximum number of draft tokens to propose.
+    pub n_max: i32,
+    /// Minimum number of draft tokens required before returning a draft.
+    pub n_min: i32,
+    /// Minimum draft probability accepted by llama.cpp's MTP drafter.
+    pub p_min: f32,
+}
+
+impl Default for MtpSpeculativeParams {
+    fn default() -> Self {
+        Self {
+            n_max: 3,
+            n_min: 0,
+            p_min: 0.0,
+        }
+    }
+}
+
+/// Errors returned by the MTP speculative wrapper.
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub enum MtpSpeculativeError {
+    /// Invalid parameters were provided.
+    #[error("invalid MTP speculative parameters")]
+    InvalidParams,
+    /// llama.cpp returned a null speculative handle.
+    #[error("llama.cpp failed to initialize MTP speculative decoding")]
+    InitFailed,
+    /// llama.cpp rejected a wrapper call.
+    #[error("llama.cpp MTP speculative call failed with status {0}")]
+    Status(i32),
+    /// The draft output exceeded the caller-provided bound.
+    #[error("llama.cpp MTP draft exceeded configured maximum")]
+    DraftOverflow,
+}
+
+/// RAII owner for a same-model MTP speculative context.
+///
+/// This wrapper currently binds llama.cpp's speculative state to sequence 0.
+/// Batches passed to [`Self::process`] must therefore contain only sequence 0.
+#[derive(Debug)]
+pub struct MtpSpeculative<'model> {
+    raw: NonNull<llama_cpp_sys_2::llama_rs_mtp_speculative>,
+    target_context: LlamaContext<'model>,
+    draft_context: LlamaContext<'model>,
+    n_max: usize,
+}
+
+impl<'model> MtpSpeculative<'model> {
+    /// Create a new MTP speculative helper from a target context and an MTP
+    /// draft context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if parameters are invalid or llama.cpp cannot
+    /// initialize the speculative implementation for the loaded model.
+    pub fn new(
+        target_context: LlamaContext<'model>,
+        draft_context: LlamaContext<'model>,
+        params: MtpSpeculativeParams,
+    ) -> Result<Self, MtpSpeculativeError> {
+        if params.n_max <= 0 || params.n_min < 0 || params.n_min > params.n_max {
+            return Err(MtpSpeculativeError::InvalidParams);
+        }
+        let n_max =
+            usize::try_from(params.n_max).map_err(|_| MtpSpeculativeError::InvalidParams)?;
+
+        let raw = unsafe {
+            llama_cpp_sys_2::llama_rs_mtp_speculative_init(
+                target_context.context.as_ptr(),
+                draft_context.context.as_ptr(),
+                params.n_max,
+                params.n_min,
+                params.p_min,
+            )
+        };
+        let raw = NonNull::new(raw).ok_or(MtpSpeculativeError::InitFailed)?;
+
+        Ok(Self {
+            raw,
+            target_context,
+            draft_context,
+            n_max,
+        })
+    }
+
+    /// Access the target context.
+    #[must_use]
+    pub fn target_context(&self) -> &LlamaContext<'model> {
+        &self.target_context
+    }
+
+    /// Access the target context for decode and cache rollback operations.
+    pub fn target_context_mut(&mut self) -> &mut LlamaContext<'model> {
+        &mut self.target_context
+    }
+
+    /// Access the draft context for cache rollback operations.
+    pub fn draft_context_mut(&mut self) -> &mut LlamaContext<'model> {
+        &mut self.draft_context
+    }
+
+    /// Begin a new generation from the given prompt tokens.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if llama.cpp rejects the call.
+    pub fn begin(&mut self, prompt_tokens: &[LlamaToken]) -> Result<(), MtpSpeculativeError> {
+        let prompt = tokens_to_raw(prompt_tokens);
+        let status = unsafe {
+            llama_cpp_sys_2::llama_rs_mtp_speculative_begin(
+                self.raw.as_ptr(),
+                prompt.as_ptr(),
+                prompt.len(),
+            )
+        };
+        status_to_result(status)
+    }
+
+    /// Process a batch that was just decoded by the target context.
+    ///
+    /// The batch must contain token input for sequence 0 only.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if llama.cpp cannot update the MTP draft context.
+    pub fn process(&mut self, batch: &LlamaBatch<'_>) -> Result<(), MtpSpeculativeError> {
+        let status = unsafe {
+            llama_cpp_sys_2::llama_rs_mtp_speculative_process(
+                self.raw.as_ptr(),
+                std::ptr::from_ref(&batch.llama_batch),
+            )
+        };
+        status_to_result(status)
+    }
+
+    /// Generate draft tokens after `id_last`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if llama.cpp rejects the draft operation or emits more
+    /// draft tokens than requested.
+    pub fn draft(
+        &mut self,
+        n_past: i32,
+        id_last: LlamaToken,
+        prompt_tokens: &[LlamaToken],
+    ) -> Result<Vec<LlamaToken>, MtpSpeculativeError> {
+        if n_past < 0 {
+            return Err(MtpSpeculativeError::InvalidParams);
+        }
+
+        let prompt = tokens_to_raw(prompt_tokens);
+        let mut raw_out = vec![0; self.n_max];
+        let mut out_len = 0_usize;
+        let status = unsafe {
+            llama_cpp_sys_2::llama_rs_mtp_speculative_draft(
+                self.raw.as_ptr(),
+                n_past,
+                id_last.0,
+                prompt.as_ptr(),
+                prompt.len(),
+                raw_out.as_mut_ptr(),
+                raw_out.len(),
+                &raw mut out_len,
+            )
+        };
+        if status == llama_cpp_sys_2::LLAMA_RS_STATUS_ALLOCATION_FAILED {
+            return Err(MtpSpeculativeError::DraftOverflow);
+        }
+        status_to_result(status)?;
+        raw_out.truncate(out_len);
+        Ok(raw_out.into_iter().map(LlamaToken).collect())
+    }
+
+    /// Notify llama.cpp how many draft tokens the target context accepted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if llama.cpp rejects the call.
+    pub fn accept(&mut self, n_accepted: u16) -> Result<(), MtpSpeculativeError> {
+        let status = unsafe {
+            llama_cpp_sys_2::llama_rs_mtp_speculative_accept(self.raw.as_ptr(), n_accepted)
+        };
+        status_to_result(status)
+    }
+}
+
+impl Drop for MtpSpeculative<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            llama_cpp_sys_2::llama_rs_mtp_speculative_free(self.raw.as_ptr());
+        }
+    }
+}
+
+fn tokens_to_raw(tokens: &[LlamaToken]) -> Vec<llama_cpp_sys_2::llama_token> {
+    tokens.iter().map(|token| token.0).collect()
+}
+
+fn status_to_result(status: llama_cpp_sys_2::llama_rs_status) -> Result<(), MtpSpeculativeError> {
+    if status_is_ok(status) {
+        Ok(())
+    } else {
+        Err(MtpSpeculativeError::Status(status as i32))
+    }
+}

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -174,6 +174,40 @@ fn extract_lib_assets(out_dir: &Path, target_os: &TargetOs) -> Vec<PathBuf> {
     files
 }
 
+fn library_file_exists(
+    search_dirs: &[PathBuf],
+    lib_name: &str,
+    build_shared_libs: bool,
+    target_os: &TargetOs,
+) -> bool {
+    let (prefixes, extensions): (&[&str], &[&str]) = match target_os {
+        TargetOs::Windows(_) => (&["", "lib"], &["lib"]),
+        TargetOs::Apple(_) => {
+            if build_shared_libs {
+                (&["lib"], &["dylib"])
+            } else {
+                (&["lib"], &["a"])
+            }
+        }
+        TargetOs::Linux | TargetOs::Android => {
+            if build_shared_libs {
+                (&["lib"], &["so"])
+            } else {
+                (&["lib"], &["a"])
+            }
+        }
+    };
+
+    search_dirs.iter().any(|dir| {
+        prefixes.iter().any(|prefix| {
+            extensions.iter().any(|extension| {
+                dir.join(format!("{prefix}{lib_name}.{extension}"))
+                    .is_file()
+            })
+        })
+    })
+}
+
 fn macos_link_search_path() -> Option<String> {
     let output = Command::new("clang")
         .arg("--print-search-dirs")
@@ -841,6 +875,7 @@ fn main() {
 
     if cfg!(feature = "cuda") {
         config.define("GGML_CUDA", "ON");
+        config.define("GGML_CUDA_NCCL", "OFF");
 
         if cfg!(feature = "cuda-no-vmm") {
             config.define("GGML_CUDA_NO_VMM", "ON");
@@ -1098,17 +1133,40 @@ fn main() {
             "cargo:rustc-link-search=native={}",
             common_lib_dir.display()
         );
+        let mut common_search_dirs = vec![common_lib_dir.clone()];
         let common_profile_dir = common_lib_dir.join(&profile);
         if common_profile_dir.is_dir() {
             println!(
                 "cargo:rustc-link-search=native={}",
                 common_profile_dir.display()
             );
+            common_search_dirs.push(common_profile_dir);
         }
-        // Newer llama.cpp renamed the common static library `common` ->
-        // `llama-common` and split base utilities into `llama-common-base`.
-        println!("cargo:rustc-link-lib=static=llama-common");
-        println!("cargo:rustc-link-lib=static=llama-common-base");
+
+        if library_file_exists(
+            &common_search_dirs,
+            "llama-common",
+            build_shared_libs,
+            &target_os,
+        ) {
+            println!("cargo:rustc-link-lib={llama_libs_kind}=llama-common");
+            if library_file_exists(
+                &common_search_dirs,
+                "llama-common-base",
+                build_shared_libs,
+                &target_os,
+            ) {
+                println!("cargo:rustc-link-lib={llama_libs_kind}=llama-common-base");
+            }
+        } else if library_file_exists(&common_search_dirs, "common", build_shared_libs, &target_os)
+        {
+            println!("cargo:rustc-link-lib={llama_libs_kind}=common");
+        } else {
+            println!(
+                "cargo:warning=common feature was enabled, but no common library was found in {}",
+                common_lib_dir.display()
+            );
+        }
     }
 
     if cfg!(feature = "system-ggml") {

--- a/llama-cpp-sys-2/wrapper_common.cpp
+++ b/llama-cpp-sys-2/wrapper_common.cpp
@@ -3,12 +3,15 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <memory>
 #include <string>
 #include <stdint.h>
+#include <vector>
 
 #include "llama.cpp/common/common.h"
 #include "llama.cpp/common/fit.h"
 #include "llama.cpp/common/json-schema-to-grammar.h"
+#include "llama.cpp/common/speculative.h"
 #include "llama.cpp/include/llama.h"
 #include "wrapper_utils.h"
 
@@ -145,4 +148,191 @@ extern "C" int llama_rs_fit_params(
 
 extern "C" void llama_rs_memory_breakdown_print(const struct llama_context * ctx) {
     common_memory_breakdown_print(ctx);
+}
+
+struct llama_rs_mtp_speculative {
+    common_params_speculative params;
+    common_speculative * spec = nullptr;
+    std::vector<llama_token> prompt;
+    std::vector<llama_token> draft;
+    size_t last_draft_len = 0;
+    bool draft_pending = false;
+};
+
+static constexpr llama_seq_id LLAMA_RS_MTP_SEQ_ID = 0;
+
+static bool llama_rs_mtp_batch_compatible(const struct llama_batch & batch) {
+    if (batch.n_tokens <= 0 || !batch.token || batch.embd || !batch.pos || !batch.n_seq_id ||
+        !batch.seq_id) {
+        return false;
+    }
+    for (int32_t k = 0; k < batch.n_tokens; ++k) {
+        if (batch.n_seq_id[k] != 1 || !batch.seq_id[k] ||
+            batch.seq_id[k][0] != LLAMA_RS_MTP_SEQ_ID) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void llama_rs_assign_tokens(
+    std::vector<llama_token> & dst,
+    const llama_token * tokens,
+    size_t count) {
+    if (count == 0) {
+        dst.clear();
+        return;
+    }
+    dst.assign(tokens, tokens + count);
+}
+
+extern "C" struct llama_rs_mtp_speculative * llama_rs_mtp_speculative_init(
+    struct llama_context * ctx_tgt,
+    struct llama_context * ctx_dft,
+    int32_t n_max,
+    int32_t n_min,
+    float p_min) {
+    if (!ctx_tgt || !ctx_dft || n_max <= 0 || n_min < 0 || n_min > n_max) {
+        return nullptr;
+    }
+
+    try {
+        auto wrapper = std::make_unique<llama_rs_mtp_speculative>();
+        wrapper->params.types = { COMMON_SPECULATIVE_TYPE_DRAFT_MTP };
+        wrapper->params.draft.ctx_tgt = ctx_tgt;
+        wrapper->params.draft.ctx_dft = ctx_dft;
+        wrapper->params.draft.n_max = n_max;
+        wrapper->params.draft.n_min = n_min;
+        wrapper->params.draft.p_min = p_min;
+
+        wrapper->spec = common_speculative_init(wrapper->params, 1);
+        if (!wrapper->spec) {
+            return nullptr;
+        }
+
+        return wrapper.release();
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+extern "C" void llama_rs_mtp_speculative_free(struct llama_rs_mtp_speculative * spec) {
+    if (!spec) {
+        return;
+    }
+    if (spec->spec) {
+        common_speculative_free(spec->spec);
+        spec->spec = nullptr;
+    }
+    delete spec;
+}
+
+extern "C" llama_rs_status llama_rs_mtp_speculative_begin(
+    struct llama_rs_mtp_speculative * spec,
+    const llama_token * prompt_tokens,
+    size_t prompt_tokens_count) {
+    if (!spec || !spec->spec || (!prompt_tokens && prompt_tokens_count > 0)) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+
+    try {
+        llama_rs_assign_tokens(spec->prompt, prompt_tokens, prompt_tokens_count);
+        spec->last_draft_len = 0;
+        spec->draft_pending = false;
+        common_speculative_begin(spec->spec, LLAMA_RS_MTP_SEQ_ID, spec->prompt);
+        return LLAMA_RS_STATUS_OK;
+    } catch (...) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    }
+}
+
+extern "C" llama_rs_status llama_rs_mtp_speculative_process(
+    struct llama_rs_mtp_speculative * spec,
+    const struct llama_batch * batch) {
+    if (!spec || !spec->spec || !batch) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+    if (!llama_rs_mtp_batch_compatible(*batch)) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+
+    try {
+        return common_speculative_process(spec->spec, *batch)
+            ? LLAMA_RS_STATUS_OK
+            : LLAMA_RS_STATUS_EXCEPTION;
+    } catch (...) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    }
+}
+
+extern "C" llama_rs_status llama_rs_mtp_speculative_draft(
+    struct llama_rs_mtp_speculative * spec,
+    llama_pos n_past,
+    llama_token id_last,
+    const llama_token * prompt_tokens,
+    size_t prompt_tokens_count,
+    llama_token * out_tokens,
+    size_t out_tokens_capacity,
+    size_t * out_tokens_count) {
+    if (!spec || !spec->spec || (!prompt_tokens && prompt_tokens_count > 0) ||
+        !out_tokens_count || n_past < 0) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+
+    try {
+        if (spec->draft_pending) {
+            return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+        }
+        llama_rs_assign_tokens(spec->prompt, prompt_tokens, prompt_tokens_count);
+        spec->draft.clear();
+        spec->last_draft_len = 0;
+
+        auto & params = common_speculative_get_draft_params(spec->spec, LLAMA_RS_MTP_SEQ_ID);
+        params = {
+            true,
+            spec->params.draft.n_max,
+            n_past,
+            id_last,
+            &spec->prompt,
+            &spec->draft,
+        };
+
+        common_speculative_draft(spec->spec);
+
+        *out_tokens_count = spec->draft.size();
+        if (spec->draft.size() > out_tokens_capacity) {
+            return LLAMA_RS_STATUS_ALLOCATION_FAILED;
+        }
+        if (!spec->draft.empty() && !out_tokens) {
+            return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+        }
+        if (!spec->draft.empty()) {
+            std::memcpy(out_tokens, spec->draft.data(), spec->draft.size() * sizeof(llama_token));
+        }
+        spec->last_draft_len = spec->draft.size();
+        spec->draft_pending = !spec->draft.empty();
+        return LLAMA_RS_STATUS_OK;
+    } catch (...) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    }
+}
+
+extern "C" llama_rs_status llama_rs_mtp_speculative_accept(
+    struct llama_rs_mtp_speculative * spec,
+    uint16_t n_accepted) {
+    if (!spec || !spec->spec) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+    if (!spec->draft_pending || n_accepted > spec->last_draft_len) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+
+    try {
+        common_speculative_accept(spec->spec, LLAMA_RS_MTP_SEQ_ID, n_accepted);
+        spec->last_draft_len = 0;
+        spec->draft_pending = false;
+        return LLAMA_RS_STATUS_OK;
+    } catch (...) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    }
 }

--- a/llama-cpp-sys-2/wrapper_common.h
+++ b/llama-cpp-sys-2/wrapper_common.h
@@ -7,6 +7,7 @@
 
 struct llama_model;
 struct llama_sampler;
+struct llama_rs_mtp_speculative;
 struct llama_vocab;
 
 #include "wrapper_utils.h"
@@ -58,6 +59,38 @@ int llama_rs_fit_params(
     enum ggml_log_level log_level);
 
 void llama_rs_memory_breakdown_print(const struct llama_context * ctx);
+
+struct llama_rs_mtp_speculative * llama_rs_mtp_speculative_init(
+    struct llama_context * ctx_tgt,
+    struct llama_context * ctx_dft,
+    int32_t n_max,
+    int32_t n_min,
+    float p_min);
+
+void llama_rs_mtp_speculative_free(struct llama_rs_mtp_speculative * spec);
+
+llama_rs_status llama_rs_mtp_speculative_begin(
+    struct llama_rs_mtp_speculative * spec,
+    const llama_token * prompt_tokens,
+    size_t prompt_tokens_count);
+
+llama_rs_status llama_rs_mtp_speculative_process(
+    struct llama_rs_mtp_speculative * spec,
+    const struct llama_batch * batch);
+
+llama_rs_status llama_rs_mtp_speculative_draft(
+    struct llama_rs_mtp_speculative * spec,
+    llama_pos n_past,
+    llama_token id_last,
+    const llama_token * prompt_tokens,
+    size_t prompt_tokens_count,
+    llama_token * out_tokens,
+    size_t out_tokens_capacity,
+    size_t * out_tokens_count);
+
+llama_rs_status llama_rs_mtp_speculative_accept(
+    struct llama_rs_mtp_speculative * spec,
+    uint16_t n_accepted);
 
 void llama_rs_string_free(char * ptr);
 


### PR DESCRIPTION
## Summary

Adds Rust bindings for llama.cpp MTP speculative decoding.

## Changes

- Updates llama.cpp to `ac7680`
- Adapts wrappers for moved common APIs
- Exposes MTP context params (`n_rs_seq`, context type)
- Adds `MtpSpeculative` safe wrapper

## Verification

- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo test -p llama-cpp-2`