### PR TITLE
Add a new Cargo feature mkl to compile llama.cpp with Intel MKL

### DIFF
--- a/examples/embeddings/Cargo.toml
+++ b/examples/embeddings/Cargo.toml
@@ -15,6 +15,7 @@ encoding_rs = { workspace = true }
 cuda = ["llama-cpp-2/cuda"]
 metal = ["llama-cpp-2/metal"]
 vulkan = ["llama-cpp-2/vulkan"]
+mkl = ["llama-cpp-2/mkl"]
 
 [lints]
 workspace = true

--- a/examples/mtmd/Cargo.toml
+++ b/examples/mtmd/Cargo.toml
@@ -13,6 +13,7 @@ encoding_rs = { workspace = true }
 cuda = ["llama-cpp-2/cuda"]
 metal = ["llama-cpp-2/metal"]
 vulkan = ["llama-cpp-2/vulkan"]
+mkl = ["llama-cpp-2/mkl"]
 
 [lints]
 workspace = true

--- a/examples/reranker/Cargo.toml
+++ b/examples/reranker/Cargo.toml
@@ -15,6 +15,7 @@ encoding_rs = { workspace = true }
 cuda = ["llama-cpp-2/cuda"]
 metal = ["llama-cpp-2/metal"]
 vulkan = ["llama-cpp-2/vulkan"]
+mkl = ["llama-cpp-2/mkl"]
 
 [lints]
 workspace = true

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -18,6 +18,7 @@ tracing-subscriber = { workspace = true }
 cuda = ["llama-cpp-2/cuda"]
 metal = ["llama-cpp-2/metal"]
 vulkan = ["llama-cpp-2/vulkan"]
+mkl = ["llama-cpp-2/mkl"]
 
 [lints]
 workspace = true

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -40,6 +40,7 @@ openmp = ["llama-cpp-sys-2/openmp"]
 # enabled. Useful for self-contained downstream binaries.
 static-openmp = ["llama-cpp-sys-2/static-openmp"]
 rocm = ["llama-cpp-sys-2/rocm"]
+mkl = ["llama-cpp-sys-2/mkl"]
 sampler = []
 # Only has an impact on Android.
 android-shared-stdcxx = ["llama-cpp-sys-2/shared-stdcxx"]

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -99,6 +99,8 @@ vulkan = []
 # (e.g. Android) point CMake at them via the OPENCL_INCLUDE_DIR / OPENCL_LIBRARY
 # env vars (build.rs forwards them), since FindOpenCL can't locate an SDK.
 opencl = []
+# Build the BLAS backend with Intel MKL (x86_64-only; requires MKLROOT set).
+mkl = []
 openmp = []
 # Link GNU OpenMP (`libgomp`) statically on GNU targets. This is useful for
 # downstreams that ship self-contained binaries while keeping OpenMP enabled.

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -883,6 +883,8 @@ fn main() {
         // The final `-lOpenCL` link is left to the top-level crate (mirroring how
         // the Android branch above leaves `-lvulkan` to it), keeping this fork
         // minimal: at runtime the device's own ICD provides the implementation.
+    }
+
     if cfg!(feature = "mkl") {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
         assert_eq!(
@@ -1101,7 +1103,10 @@ fn main() {
                 found = true;
             }
         }
-        assert!(found, "No MKL library directory found under MKLROOT={mkl_root}");
+        assert!(
+            found,
+            "No MKL library directory found under MKLROOT={mkl_root}"
+        );
 
         println!("cargo:rustc-link-lib=dylib=mkl_rt");
     }

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -883,6 +883,14 @@ fn main() {
         // The final `-lOpenCL` link is left to the top-level crate (mirroring how
         // the Android branch above leaves `-lvulkan` to it), keeping this fork
         // minimal: at runtime the device's own ICD provides the implementation.
+    if cfg!(feature = "mkl") {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        assert_eq!(
+            target_arch, "x86_64",
+            "The `mkl` feature requires an x86_64 target; Intel MKL is unavailable for {target_arch}."
+        );
+        config.define("GGML_BLAS", "ON");
+        config.define("GGML_BLAS_VENDOR", "Intel10_64lp");
     }
 
     // Android doesn't have OpenMP support AFAICT and openmp is a default feature. Do this here
@@ -1077,6 +1085,25 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=amdhip64");
         println!("cargo:rustc-link-lib=dylib=rocblas");
         println!("cargo:rustc-link-lib=dylib=hipblas");
+    }
+
+    if cfg!(feature = "mkl") && !build_shared_libs {
+        println!("cargo:rerun-if-env-changed=MKLROOT");
+
+        let mkl_root = env::var("MKLROOT")
+            .expect("Intel MKL not found. Please install Intel oneAPI/MKL and set MKLROOT.");
+
+        let mut found = false;
+        for sub in ["lib/intel64", "lib"] {
+            let dir = Path::new(&mkl_root).join(sub);
+            if dir.is_dir() {
+                println!("cargo:rustc-link-search=native={}", dir.display());
+                found = true;
+            }
+        }
+        assert!(found, "No MKL library directory found under MKLROOT={mkl_root}");
+
+        println!("cargo:rustc-link-lib=dylib=mkl_rt");
     }
 
     // Link libraries


### PR DESCRIPTION
The PR is related to the issue https://github.com/utilityai/llama-cpp-rs/issues/1032.

In some scenarios, especially for CPU inference, we want to compile llama.cpp with Intel MKL acceleration. llama.cpp already supports it. See: https://github.com/ggml-org/llama.cpp/blob/master/ggml/src/ggml-blas/CMakeLists.txt.

By adding the feature `mkl`, the compilation config `GGML_BLAS=ON` and `GGML_BLAS_VENDOR=Intel10_64lp`  can be added when the crate llama-cpp-sys compiles the llama.cpp.