### PR TITLE
Add static-openmp and static-stdcxx feature flags

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -38,11 +38,17 @@ metal = ["llama-cpp-sys-2/metal"]
 dynamic-link = ["llama-cpp-sys-2/dynamic-link"]
 vulkan = ["llama-cpp-sys-2/vulkan"]
 openmp = ["llama-cpp-sys-2/openmp"]
+# Link GNU OpenMP (`libgomp`) statically on GNU targets while keeping OpenMP
+# enabled. Useful for self-contained downstream binaries.
+static-openmp = ["llama-cpp-sys-2/static-openmp"]
 rocm = ["llama-cpp-sys-2/rocm"]
 sampler = []
 # Only has an impact on Android.
 android-shared-stdcxx = ["llama-cpp-sys-2/shared-stdcxx"]
 android-static-stdcxx = ["llama-cpp-sys-2/static-stdcxx"]
+# Generic alias for non-Android targets that also support static C++ stdlib
+# linkage through the sys crate.
+static-stdcxx = ["llama-cpp-sys-2/static-stdcxx"]
 mtmd = ["llama-cpp-sys-2/mtmd"]
 system-ggml = ["llama-cpp-sys-2/system-ggml"]
 system-ggml-static = ["llama-cpp-sys-2/system-ggml-static"]

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -97,10 +97,14 @@ metal = []
 dynamic-link = []
 vulkan = []
 openmp = []
+# Link GNU OpenMP (`libgomp`) statically on GNU targets. This is useful for
+# downstreams that ship self-contained binaries while keeping OpenMP enabled.
+static-openmp = ["openmp"]
 rocm = []
-# Only has an impact on Android.
-shared-stdcxx = []
+# Link the C++ standard library statically where the target toolchain supports
+# it. Currently used by Android and Linux GNU/musl targets.
 static-stdcxx = []
+shared-stdcxx = []
 system-ggml = []
 system-ggml-static = ["system-ggml"]
 mtmd = []

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -30,6 +30,28 @@ macro_rules! debug_log {
     };
 }
 
+fn emit_compiler_static_archive_search_path(archive: &str) {
+    let compiler = cc::Build::new().get_compiler();
+    let Ok(output) = Command::new(compiler.path())
+        .arg(format!("--print-file-name={archive}"))
+        .output()
+    else {
+        return;
+    };
+
+    if !output.status.success() {
+        return;
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let path = Path::new(&path);
+    if path.is_file() {
+        if let Some(parent) = path.parent() {
+            println!("cargo:rustc-link-search=native={}", parent.display());
+        }
+    }
+}
+
 fn parse_target_os() -> Result<(TargetOs, String), String> {
     let target = env::var("TARGET").unwrap();
 
@@ -1060,7 +1082,12 @@ fn main() {
 
     // OpenMP
     if cfg!(feature = "openmp") && target_triple.contains("gnu") {
-        println!("cargo:rustc-link-lib=gomp");
+        if cfg!(feature = "static-openmp") {
+            emit_compiler_static_archive_search_path("libgomp.a");
+            println!("cargo:rustc-link-lib=static=gomp");
+        } else {
+            println!("cargo:rustc-link-lib=gomp");
+        }
     }
 
     match target_os {
@@ -1078,7 +1105,12 @@ fn main() {
             }
         }
         TargetOs::Linux => {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
+            if cfg!(feature = "static-stdcxx") {
+                emit_compiler_static_archive_search_path("libstdc++.a");
+                println!("cargo:rustc-link-lib=static=stdc++");
+            } else {
+                println!("cargo:rustc-link-lib=dylib=stdc++");
+            }
         }
         TargetOs::Apple(ref variant) => {
             println!("cargo:rustc-link-lib=framework=Foundation");


### PR DESCRIPTION
This adds two opt-in features: `static-openmp` links libgomp statically (and implies `openmp`), and `static-stdcxx` does the same for libstdc++ on Linux. The sys crate already had `static-stdcxx` for Android, so this mostly just wires it up for Linux and exposes it from `llama-cpp-2`.

The motivation: I'm building [fono](https://github.com/bogdanr/fono), a local voice assistant that ships as a single self-contained binary, and `libgomp.so.1` and `libstdc++.so.6` were the last two runtime dependencies I couldn't get rid of. With these two features the binary runs on any glibc system without needing the GCC runtime libs installed. I kept OpenMP itself on because dropping it costs real inference speed — it's just the linkage that changes.

The static archives are found by asking the compiler with `--print-file-name`, which is what other -sys crates do for this. Defaults are untouched — build without these features and the link line is exactly what it is on main today.

Tested on x86_64 Linux by building the `usage` example both ways: with the features on, `ldd` shows no libgomp or libstdc++ entries; with them off, it matches main. We've been running fono on this branch for a while now without issues.