### PR TITLE
make llguidance sample a eos after the grammar completes

### DIFF
--- a/llama-cpp-2/src/llguidance_sampler.rs
+++ b/llama-cpp-2/src/llguidance_sampler.rs
@@ -89,7 +89,7 @@ unsafe extern "C" fn llg_apply(
     let ctx = unsafe { &mut *(*smpl).ctx.cast::<LlgContext>() };
     let cur_p = unsafe { &mut *cur_p };
 
-    let Ok(mask) = ctx.matcher.compute_mask() else {
+    let Ok(mask) = ctx.matcher.compute_mask_or_eos() else {
         return;
     };
 


### PR DESCRIPTION
The current llguidance implementation will happily continue with stuff that doesn't conform to the grammar, after completing the grammar. This differs from the behavior of the llama.cpp grammar sampler, which forces eos after the grammar.

This is just a tiny change to the usage of llguidance to force an eos after completion of the grammar.