### PR TITLE
Bumped version to 0.1.149

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embeddings"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "anyhow",
  "clap",
@@ -1160,7 +1160,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "bindgen",
  "cc",
@@ -1902,7 +1902,7 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple"
-version = "0.1.148"
+version = "0.1.149"
 dependencies = [
  "anyhow",
  "clap",

--- a/examples/embeddings/Cargo.toml
+++ b/examples/embeddings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embeddings"
-version = "0.1.148"
+version = "0.1.149"
 edition = "2021"
 publish = false
 

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple"
-version = "0.1.148"
+version = "0.1.149"
 edition = "2021"
 publish = false
 

--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-2"
 description = "llama.cpp bindings for Rust"
-version = "0.1.148"
+version = "0.1.149"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"
@@ -10,7 +10,7 @@ repository = "https://github.com/utilityai/llama-cpp-rs"
 
 [dependencies]
 enumflags2 = "0.7.12"
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.148" }
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.149" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
@@ -54,7 +54,7 @@ dynamic-backends = ["llama-cpp-sys-2/dynamic-backends"]
 
 
 [target.'cfg(all(target_os = "macos", any(target_arch = "aarch64", target_arch = "arm64")))'.dependencies]
-llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.148", features = [
+llama-cpp-sys-2 = { path = "../llama-cpp-sys-2", version = "0.1.149", features = [
     "metal",
 ] }
 

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llama-cpp-sys-2"
 description = "Low Level Bindings to llama.cpp"
-version = "0.1.148"
+version = "0.1.149"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/utilityai/llama-cpp-rs"


### PR DESCRIPTION
Bumps the workspace crates from 0.1.148 to 0.1.149 so a release tagged `0.1.149` publishes crate `0.1.149` (tag == published version).

Context: crates.io is currently at `0.1.147`; the `0.1.148` release published `0.1.147` due to the version-lag bug, and tag `0.1.148` already exists on GitHub. Bumping to `0.1.149` gives a clean, well-synced release point.

After merging, cut a release tagged `0.1.149` to publish.

Mirrors the previous auto-bump commits exactly: package versions for the 4 workspace crates, the `llama-cpp-sys-2` dependency pin in `llama-cpp-2` (both occurrences), and `Cargo.lock`. The workflow fix (tag-derived version + retry) will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)