### PR TITLE
Add `opencl` feature for the Adreno/Qualcomm GPU backend

### DIFF
--- a/llama-cpp-2/Cargo.toml
+++ b/llama-cpp-2/Cargo.toml
@@ -34,6 +34,7 @@ cuda-no-vmm = ["cuda", "llama-cpp-sys-2/cuda-no-vmm"]
 metal = ["llama-cpp-sys-2/metal"]
 dynamic-link = ["llama-cpp-sys-2/dynamic-link"]
 vulkan = ["llama-cpp-sys-2/vulkan"]
+opencl = ["llama-cpp-sys-2/opencl"]
 openmp = ["llama-cpp-sys-2/openmp"]
 # Link GNU OpenMP (`libgomp`) statically on GNU targets while keeping OpenMP
 # enabled. Useful for self-contained downstream binaries.

--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -48,6 +48,7 @@ include = [
     "/llama.cpp/ggml/src/ggml-cuda/**/*",
     "/llama.cpp/ggml/src/ggml-metal/**/*",
     "/llama.cpp/ggml/src/ggml-vulkan/**/*",
+    "/llama.cpp/ggml/src/ggml-opencl/**/*",
     "/llama.cpp/ggml/src/ggml-hip/**/*",
 
     "/llama.cpp/ggml/src/llamafile/sgemm.h",
@@ -93,6 +94,11 @@ cuda-no-vmm = ["cuda"]
 metal = []
 dynamic-link = []
 vulkan = []
+# OpenCL backend (GGML_OPENCL=ON) — the Qualcomm-supported path for Adreno GPUs.
+# The build needs OpenCL headers + a libOpenCL.so to link; on a cross-compile
+# (e.g. Android) point CMake at them via the OPENCL_INCLUDE_DIR / OPENCL_LIBRARY
+# env vars (build.rs forwards them), since FindOpenCL can't locate an SDK.
+opencl = []
 openmp = []
 # Link GNU OpenMP (`libgomp`) statically on GNU targets. This is useful for
 # downstreams that ship self-contained binaries while keeping OpenMP enabled.

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -851,6 +851,40 @@ fn main() {
         config.define("GGML_HIP", "ON");
     }
 
+    if cfg!(feature = "opencl") {
+        // The Qualcomm-supported GPU backend for Adreno. EMBED_KERNELS and
+        // USE_ADRENO_KERNELS are ON by default upstream, so no extra defines are
+        // needed for those.
+        config.define("GGML_OPENCL", "ON");
+
+        // ggml-opencl/CMakeLists.txt runs `find_package(OpenCL REQUIRED)`. When
+        // cross-compiling (e.g. Android, whose NDK ships no OpenCL SDK) CMake's
+        // FindOpenCL can't locate one, so let the caller hand us the header dir
+        // and the import library directly — FindOpenCL skips its own search when
+        // these result variables are already set.
+        println!("cargo:rerun-if-env-changed=OPENCL_INCLUDE_DIR");
+        println!("cargo:rerun-if-env-changed=OPENCL_LIBRARY");
+        if let Ok(include_dir) = env::var("OPENCL_INCLUDE_DIR") {
+            config.define("OpenCL_INCLUDE_DIR", include_dir);
+        }
+        if let Ok(library) = env::var("OPENCL_LIBRARY") {
+            config.define("OpenCL_LIBRARY", library);
+        }
+
+        // The backend embeds its kernels at build time with a Python helper
+        // (`find_package(Python3 REQUIRED)`); allow pinning the interpreter so a
+        // cross-build doesn't pick a broken stub `python3` (e.g. the Windows
+        // Store alias). When unset, CMake's FindPython3 runs as usual.
+        println!("cargo:rerun-if-env-changed=PYTHON3_EXECUTABLE");
+        if let Ok(python3) = env::var("PYTHON3_EXECUTABLE") {
+            config.define("Python3_EXECUTABLE", python3);
+        }
+
+        // The final `-lOpenCL` link is left to the top-level crate (mirroring how
+        // the Android branch above leaves `-lvulkan` to it), keeping this fork
+        // minimal: at runtime the device's own ICD provides the implementation.
+    }
+
     // Android doesn't have OpenMP support AFAICT and openmp is a default feature. Do this here
     // rather than modifying the defaults in Cargo.toml just in case someone enables the OpenMP feature
     // and tries to build for Android anyway.


### PR DESCRIPTION
## What

Adds an `opencl` Cargo feature that enables llama.cpp's **OpenCL backend** (`GGML_OPENCL=ON`) — Qualcomm's supported GPU path for **Adreno** devices. It mirrors the existing `vulkan` / `cuda` / `rocm` wiring and is a no-op unless the feature is enabled:

- **`llama-cpp-sys-2`**: `opencl` feature → `config.define("GGML_OPENCL", "ON")` (next to the `rocm` block in `build.rs`); adds `ggml-opencl/**/*` to the crate `include` allowlist so the backend sources are packaged.
- **`llama-cpp-2`**: `opencl = ["llama-cpp-sys-2/opencl"]`.

## Why the optional env vars

`ggml/src/ggml-opencl/CMakeLists.txt` does `find_package(OpenCL REQUIRED)` and `find_package(Python3 REQUIRED)` (it embeds its kernels via a Python helper). On a desktop with an OpenCL SDK installed, `find_package(OpenCL)` resolves on its own. On a **cross-compile** (e.g. Android — the NDK ships no OpenCL SDK) it can't, so the feature lets the caller hand CMake the paths directly via optional env vars. All three are read only behind `cfg!(feature = "opencl")` and are no-ops when unset, so desktop and other-backend builds are unaffected:

- `OPENCL_INCLUDE_DIR` → `-DOpenCL_INCLUDE_DIR`
- `OPENCL_LIBRARY` → `-DOpenCL_LIBRARY`
- `PYTHON3_EXECUTABLE` → `-DPython3_EXECUTABLE` (lets a cross-build pin the interpreter past, e.g., the broken Windows-Store `python3` alias)

The final `-lOpenCL` link is left to the consumer — exactly as the Android branch already leaves `-lvulkan` — keeping this change minimal.

## Validation

Cross-compiled `llama-cpp-sys-2` + `llama-cpp-2` with `--features opencl` for `aarch64-linux-android` (NDK r27c) and ran on a **Qualcomm Adreno 750 (Snapdragon 8 Gen 3)**:

```
ggml_opencl: device: 'QUALCOMM Adreno(TM) 750 (OpenCL 3.0 Adreno(TM) 750)'
ggml_opencl: using kernels optimized for Adreno
llama_model_load_from_file_impl: using device GPUOpenCL (QUALCOMM Adreno(TM) 750)
```

The model loads, layers offload, `graph_reserve` completes, and generation produces tokens. (Vulkan, by contrast, crashes on Adreno — the documented [ggml-org/llama.cpp#9464](https://github.com/ggml-org/llama.cpp/discussions/9464) / [#6337](https://github.com/ggml-org/llama.cpp/issues/6337) — so OpenCL is the real Adreno path.) Prefill measured ~4–7.5× faster than CPU on Qwen 4B/7B Q4.
