### PR TITLE
feat: expose model-load progress callback on LlamaModelParams

### DIFF
--- a/llama-cpp-2/src/model/params.rs
+++ b/llama-cpp-2/src/model/params.rs
@@ -3,7 +3,7 @@
 use crate::context::params::LlamaContextParams;
 use crate::model::params::kv_overrides::KvOverrides;
 use crate::LlamaCppError;
-use std::ffi::{c_char, CStr};
+use std::ffi::{c_char, c_void, CStr};
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::ptr::null;
@@ -150,6 +150,7 @@ pub struct LlamaModelParams {
     buft_overrides: Vec<llama_cpp_sys_2::llama_model_tensor_buft_override>,
     devices: Pin<Box<[llama_cpp_sys_2::ggml_backend_dev_t; LLAMA_CPP_MAX_DEVICES]>>,
     tensor_split: Vec<f32>,
+    progress_callback: Option<Box<dyn FnMut(f32) -> bool>>,
 }
 
 impl Debug for LlamaModelParams {
@@ -556,6 +557,25 @@ impl LlamaModelParams {
     pub fn no_alloc(&self) -> bool {
         self.params.no_alloc
     }
+
+    /// Sets a callback invoked during loading with progress in `0.0..=1.0`.
+    /// Returning `false` aborts the load (it then fails with `NullResult`).
+    #[must_use]
+    pub fn with_progress_callback<F: FnMut(f32) -> bool + 'static>(mut self, callback: F) -> Self {
+        unsafe extern "C" fn trampoline<F: FnMut(f32) -> bool>(
+            progress: f32,
+            user_data: *mut c_void,
+        ) -> bool {
+            let callback = unsafe { &mut *user_data.cast::<F>() };
+            callback(progress)
+        }
+
+        let mut callback = Box::new(callback);
+        self.params.progress_callback_user_data = std::ptr::from_mut(&mut *callback).cast::<c_void>();
+        self.params.progress_callback = Some(trampoline::<F>);
+        self.progress_callback = Some(callback);
+        self
+    }
 }
 
 /// Default parameters for `LlamaModel`. (as defined in llama.cpp by `llama_model_default_params`)
@@ -591,6 +611,7 @@ impl Default for LlamaModelParams {
             }],
             devices: Box::pin([std::ptr::null_mut(); 16]),
             tensor_split: Vec::new(),
+            progress_callback: None,
         }
     }
 }
@@ -613,5 +634,30 @@ mod tests {
             i32::from(LlamaSplitMode::Tensor),
             llama_cpp_sys_2::LLAMA_SPLIT_MODE_TENSOR as i32
         );
+    }
+
+    #[test]
+    fn progress_callback_round_trips_and_can_abort() {
+        use super::LlamaModelParams;
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let calls = Rc::new(Cell::new(0_u32));
+        let counter = Rc::clone(&calls);
+        let params = LlamaModelParams::default().with_progress_callback(move |_progress| {
+            counter.set(counter.get() + 1);
+            false
+        });
+
+        assert!(params.params.progress_callback.is_some());
+        assert!(!params.params.progress_callback_user_data.is_null());
+
+        let trampoline = params.params.progress_callback.unwrap();
+        let user_data = params.params.progress_callback_user_data;
+        let first = unsafe { trampoline(0.5, user_data) };
+        let second = unsafe { trampoline(1.0, user_data) };
+
+        assert!(!first && !second, "returning false signals an abort");
+        assert_eq!(calls.get(), 2);
     }
 }


### PR DESCRIPTION
The C `llama_model_params` struct already has `progress_callback` and
`progress_callback_user_data`, but there's no way to set them from the safe API.
This adds a `with_progress_callback` builder that takes a Rust closure.

The closure gets the load progress (0.0 to 1.0) and returns a bool: `true` keeps
loading, `false` aborts. On abort llama.cpp stops, frees the partially loaded
model and returns NULL, so `load_from_file` returns `Err(NullResult)`. This is
llama.cpp's own cancel path (it even logs "cancelled model load").

My use case is an app where the user can switch between models. A big model can
take a while to load, and if the user picks a different one mid-load I want to
cancel the current load and start the new one instead of waiting for the first
to finish.

A few implementation notes:
- The closure is boxed and stored in the params, so the `user_data` pointer
  stays valid for the whole load and gets freed when the params drop.
- `load_from_file` already passes `params.params` to C, so it picks up the
  callback with no other changes needed.
- Backward compatible: default params leave the callback null, same as today.

I also added a unit test that sets a callback, calls the trampoline the way
llama.cpp would, and checks it forwards the progress value and that the FnMut
state survives across calls.

Happy to reshape it if you'd prefer something different (naming, generic vs
boxed dyn, etc.).
