### PR TITLE
Fix vulkan build on x86_64-pc-windows-gnu (MSVC-only /FS flag, .a archive discovery)

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -100,7 +100,9 @@ fn get_cargo_target_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
 
 fn extract_lib_names(out_dir: &Path, build_shared_libs: bool, target_os: &TargetOs) -> Vec<String> {
     let lib_pattern = match target_os {
-        TargetOs::Windows(_) => "*.lib",
+        // MSVC emits .lib; the GNU (MinGW) toolchain emits .a static archives.
+        TargetOs::Windows(WindowsVariant::Msvc) => "*.lib",
+        TargetOs::Windows(_) => "*.a",
         TargetOs::Apple(_) => {
             if build_shared_libs {
                 "*.dylib"
@@ -867,11 +869,15 @@ fn main() {
                 // limit configuration set in the windows registry.
                 // I'm not sure why that's a thing, but this makes my builds work.
                 // (crates that depend on llama-cpp-rs w/ vulkan easily exceed the default PATH_MAX on windows)
-                env::set_var("TrackFileAccess", "false");
-                // since we disabled TrackFileAccess, we can now run into problems with parallel
-                // access to pdb files. /FS solves this.
-                config.cflag("/FS");
-                config.cxxflag("/FS");
+                // MSVC-only: MSBuild FileTracker and /FS do not exist on the GNU (MinGW)
+                // toolchain — gcc parses "/FS" as a linker input path and fails.
+                if matches!(target_os, TargetOs::Windows(WindowsVariant::Msvc)) {
+                    env::set_var("TrackFileAccess", "false");
+                    // since we disabled TrackFileAccess, we can now run into problems with parallel
+                    // access to pdb files. /FS solves this.
+                    config.cflag("/FS");
+                    config.cxxflag("/FS");
+                }
             }
             TargetOs::Linux => {
                 // If we are not using system provided vulkan SDK, add vulkan libs for linking


### PR DESCRIPTION
Two small `build.rs` fixes that unbreak `--features vulkan` for the GNU (MinGW) Windows target. Both changes are inside Windows-only match arms and are further restricted by variant, so MSVC and non-Windows builds are untouched.

## 1. `/FS` cflag applied to gcc
The MSBuild FileTracker workaround (`TrackFileAccess=false` + `/FS`) was applied for every `TargetOs::Windows(_)`. On windows-gnu, gcc parses `/FS` as a linker input path and CMake's compiler sanity check dies:

```
cc.exe: error: /FS: linker input file not found: No such file or directory
```

Now applied only for `WindowsVariant::Msvc` (the flag and FileTracker don't exist on the GNU toolchain).

## 2. Static archive discovery globbed `*.lib` only
`extract_lib_names` used the `*.lib` pattern for every Windows variant, but MinGW emits `.a` archives — so after a fully successful cmake build (including `ggml-vulkan.a`), the build script panicked at `assert_ne!(llama_libs.len(), 0)`. The non-MSVC Windows variants now glob `*.a`; the existing lib-prefix normalization already handles both `ggml.a` and `libllama.a` shapes.

## Testing
On `x86_64-pc-windows-gnu` (MinGW-Builds GCC 15.2, Ninja, Vulkan SDK 1.4.350, AMD Radeon RX 7900 XT):
`cargo build --release -p simple --features vulkan` builds, and the `simple` example runs Llama-3.1-8B Q4_K_M fully offloaded via Vulkan at ~118 t/s decode.

Note: one more windows-gnu link problem remains after these fixes (cmake's generated `build-info.cpp` objects never reach the GNU link line) — filed separately with analysis and a workaround as #1059, since the right fix is a design choice.