### PR TITLE
Added new_context_with_other for Gemma 4 MTP

### DIFF
--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -824,7 +824,7 @@ impl LlamaModel {
     ///
     /// See [`LlamaContextLoadError`].
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new_context_with_other<'a>(
+    pub fn new_context_with_ctx_other<'a>(
         &'a self,
         _: &LlamaBackend,
         params: LlamaContextParams,

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -814,6 +814,32 @@ impl LlamaModel {
         Ok(LlamaContext::new(self, context, params.embeddings()))
     }
 
+    /// Create a new context bound to another context via llama.cpp's `ctx_other` field.
+    ///
+    /// This is required for MTP speculative decoding when the target model's
+    /// architecture uses `LLM_ARCH_GEMMA4_ASSISTANT`, which asserts that the draft
+    /// context references the target context so KV state can be shared.
+    ///
+    /// # Errors
+    ///
+    /// See [`LlamaContextLoadError`].
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_context_with_other<'a>(
+        &'a self,
+        _: &LlamaBackend,
+        params: LlamaContextParams,
+        ctx_other: &LlamaContext<'_>,
+    ) -> Result<LlamaContext<'a>, LlamaContextLoadError> {
+        let mut context_params = params.context_params;
+        context_params.ctx_other = ctx_other.context.as_ptr();
+        let context = unsafe {
+            llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
+        };
+        let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
+
+        Ok(LlamaContext::new(self, context, params.embeddings()))
+    }
+
     /// Apply the models chat template to some messages.
     /// See <https://github.com/ggerganov/llama.cpp/wiki/Templates-supported-by-llama_chat_apply_template>
     ///


### PR DESCRIPTION
MTP support was recently added, however there is a hard coded check in llama.cpp for Gemma 4.

The code snippet is as follows:

```
// src/llama-context.cpp — inside the llama_context constructor
  cparams.ctx_other = nullptr;

  // TODO: more generic
  if (model.arch == LLM_ARCH_GEMMA4_ASSISTANT) {
      if (params.ctx_other == nullptr) {
          // TODO: change from runtime_error to llama_exception to avoid printing error message
          throw std::runtime_error("Gemma4Assistant requires ctx_other to be set (this is normal during memory fitting)");
      }

      cparams.ctx_other = params.ctx_other;
  }
```

and appears in src/llama-context.cpp (inside llama-cpp-sys-2/llama.cpp/ in the llama-cpp-rs tree), line 88-98.

Gemma4 MTP wont work without access to ctx_other in way.

The proposed fix is a new function: new_context_with_other
