### PR TITLE
feat: add llguidance_with_slices to supply custom slice regexes

### DIFF
--- a/llama-cpp-2/src/llguidance_sampler.rs
+++ b/llama-cpp-2/src/llguidance_sampler.rs
@@ -4,10 +4,10 @@
 //! to enforce grammar constraints (JSON schema, regex, Lark, etc.) during token sampling.
 
 use std::ffi::c_void;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use llguidance::Matcher;
-use toktrie::{ApproximateTokEnv, TokRxInfo, TokTrie};
+use toktrie::{ApproximateTokEnv, TokEnv, TokRxInfo, TokTrie};
 
 use crate::model::LlamaModel;
 use crate::sampling::LlamaSampler;
@@ -15,19 +15,23 @@ use crate::token::LlamaToken;
 use crate::GrammarError;
 
 /// Internal state for the llguidance sampler.
+///
+/// A [`Matcher`] is self-contained (it owns its own tokenizer environment and parser
+/// state internally), so this is all the per-instance state the vtable callbacks need.
 struct LlgContext {
     matcher: Matcher,
-    tok_env: Arc<ApproximateTokEnv>,
-    grammar_kind: String,
-    grammar_data: String,
 }
 
 /// Build a [`toktrie::TokEnv`] from a [`LlamaModel`]'s vocabulary.
 ///
+/// Use this to construct your own `llguidance::ParserFactory` (with any slice regexes,
+/// inference capabilities, or other configuration llguidance supports) and, from it, a
+/// `llguidance::Matcher` to pass to [`create_llg_sampler_from_matcher`].
+///
 /// This mirrors the logic in upstream `llguidance.cpp` — for each token:
 /// - Try normal detokenize (special=false)
 /// - If empty, detokenize with special=true and prefix with 0xFF marker byte
-fn build_tok_env(model: &LlamaModel) -> Arc<ApproximateTokEnv> {
+pub fn llguidance_build_tok_env(model: &LlamaModel) -> TokEnv {
     let n_vocab = model.n_vocab().cast_unsigned();
     let tok_eos = {
         let eot = unsafe { llama_cpp_sys_2::llama_vocab_eot(model.vocab_ptr()) };
@@ -112,15 +116,9 @@ unsafe extern "C" fn llg_clone(
     let ctx = unsafe { &*(*smpl).ctx.cast::<LlgContext>() };
     let new_ctx = Box::new(LlgContext {
         matcher: ctx.matcher.deep_clone(),
-        tok_env: Arc::clone(&ctx.tok_env),
-        grammar_kind: ctx.grammar_kind.clone(),
-        grammar_data: ctx.grammar_data.clone(),
     });
     unsafe {
-        llama_cpp_sys_2::llama_sampler_init(
-            &raw mut LLG_SAMPLER_I,
-            Box::into_raw(new_ctx).cast::<c_void>(),
-        )
+        llama_cpp_sys_2::llama_sampler_init(llg_vtable(), Box::into_raw(new_ctx).cast::<c_void>())
     }
 }
 
@@ -131,76 +129,62 @@ unsafe extern "C" fn llg_free(smpl: *mut llama_cpp_sys_2::llama_sampler) {
     }
 }
 
-static mut LLG_SAMPLER_I: llama_cpp_sys_2::llama_sampler_i = llama_cpp_sys_2::llama_sampler_i {
-    name: Some(llg_name),
-    accept: Some(llg_accept),
-    apply: Some(llg_apply),
-    reset: Some(llg_reset),
-    clone: Some(llg_clone),
-    free: Some(llg_free),
-    backend_init: None,
-    backend_accept: None,
-    backend_apply: None,
-    backend_set_input: None,
-};
+/// Returns a pointer to the llguidance sampler vtable.
+///
+/// The vtable's function pointers never change after construction, so a single instance
+/// is built lazily and shared by every llguidance sampler (and its clones) — only the
+/// per-instance `ctx` differs. This avoids a `static mut`.
+fn llg_vtable() -> *mut llama_cpp_sys_2::llama_sampler_i {
+    static VTABLE: OnceLock<Box<llama_cpp_sys_2::llama_sampler_i>> = OnceLock::new();
+    let vtable = VTABLE.get_or_init(|| {
+        Box::new(llama_cpp_sys_2::llama_sampler_i {
+            name: Some(llg_name),
+            accept: Some(llg_accept),
+            apply: Some(llg_apply),
+            reset: Some(llg_reset),
+            clone: Some(llg_clone),
+            free: Some(llg_free),
+            backend_init: None,
+            backend_accept: None,
+            backend_apply: None,
+            backend_set_input: None,
+        })
+    });
+    std::ptr::from_ref(vtable.as_ref()).cast_mut()
+}
+
+/// Wrap an already-built [`llguidance::Matcher`] into a [`LlamaSampler`].
+///
+/// This is the generic entry point: build a [`TokEnv`] via [`llguidance_build_tok_env`], your
+/// own `llguidance::ParserFactory` (with whatever slices, inference capabilities, or other
+/// llguidance configuration you need), parse your grammar into a `Matcher`, and hand it
+/// here. This function only adapts the `Matcher` into the `llama_sampler` vtable — it has
+/// no opinion on how the `Matcher` was built.
+pub(crate) fn create_llg_sampler_from_matcher(matcher: Matcher) -> LlamaSampler {
+    let ctx = Box::new(LlgContext { matcher });
+    let sampler = unsafe {
+        llama_cpp_sys_2::llama_sampler_init(llg_vtable(), Box::into_raw(ctx).cast::<c_void>())
+    };
+    LlamaSampler { sampler }
+}
 
 /// Create an llguidance-based constrained decoding sampler.
 ///
 /// Uses `ParserFactory::new_simple`, which pre-builds a `SlicedBiasComputer` with the
-/// four general JSON regexes. Prefer [`create_llg_sampler_with_slices`] when you know
-/// which token sub-sets are valid for your grammar — it can cut per-token constraint
-/// cost significantly on large vocabularies.
+/// four general JSON regexes. For custom slice regexes or other `ParserFactory`
+/// configuration, build your own `llguidance::Matcher` (via [`llguidance_build_tok_env`] and the
+/// `llguidance` crate directly) and pass it to [`create_llg_sampler_from_matcher`] instead.
 pub(crate) fn create_llg_sampler(
     model: &LlamaModel,
     grammar_kind: &str,
     grammar_data: &str,
 ) -> Result<LlamaSampler, GrammarError> {
-    let tok_env = build_tok_env(model);
+    let tok_env = llguidance_build_tok_env(model);
     let tok_env_dyn: Arc<dyn toktrie::TokenizerEnv + Sync> = tok_env.clone();
 
     let factory = llguidance::ParserFactory::new_simple(&tok_env_dyn)
         .map_err(|_| GrammarError::NullGrammar)?;
 
-    finish_llg_sampler(tok_env, factory, grammar_kind, grammar_data)
-}
-
-/// Create an llguidance-based constrained decoding sampler with caller-supplied slice regexes.
-///
-/// `slices` is a list of regex strings. At startup, each regex is matched against the
-/// entire vocabulary and the matching tokens are stored in a pre-built bitmask. During
-/// inference, whenever only tokens matching a slice regex could be valid at the current
-/// position, llguidance uses that bitmask directly instead of walking the full vocabulary
-/// trie — cutting per-token cost significantly on large vocabularies.
-///
-/// Pass an empty slice list to disable the optimization entirely (falls back to a full
-/// trie walk on every token). Use [`llguidance::SlicedBiasComputer::general_slices`] for
-/// JSON-heavy grammars, or supply custom patterns suited to your output format
-/// (e.g. `[^<>{},:]+` for delimiter-bounded formats like Gemma-4 tool calls).
-pub(crate) fn create_llg_sampler_with_slices(
-    model: &LlamaModel,
-    grammar_kind: &str,
-    grammar_data: &str,
-    slices: &[String],
-) -> Result<LlamaSampler, GrammarError> {
-    let tok_env = build_tok_env(model);
-    let tok_env_dyn: Arc<dyn toktrie::TokenizerEnv + Sync> = tok_env.clone();
-
-    let factory = llguidance::ParserFactory::new(
-        &tok_env_dyn,
-        toktrie::InferenceCapabilities::default(),
-        slices,
-    )
-    .map_err(|_| GrammarError::NullGrammar)?;
-
-    finish_llg_sampler(tok_env, factory, grammar_kind, grammar_data)
-}
-
-fn finish_llg_sampler(
-    tok_env: Arc<ApproximateTokEnv>,
-    factory: llguidance::ParserFactory,
-    grammar_kind: &str,
-    grammar_data: &str,
-) -> Result<LlamaSampler, GrammarError> {
     let grammar = llguidance::api::TopLevelGrammar::from_tagged_str(grammar_kind, grammar_data)
         .map_err(|_| GrammarError::NullGrammar)?;
 
@@ -210,18 +194,10 @@ fn finish_llg_sampler(
 
     let matcher = Matcher::new(Ok(parser));
 
-    let ctx = Box::new(LlgContext {
-        matcher,
-        tok_env,
-        grammar_kind: grammar_kind.to_string(),
-        grammar_data: grammar_data.to_string(),
-    });
+    let ctx = Box::new(LlgContext { matcher });
 
     let sampler = unsafe {
-        llama_cpp_sys_2::llama_sampler_init(
-            &raw mut LLG_SAMPLER_I,
-            Box::into_raw(ctx).cast::<c_void>(),
-        )
+        llama_cpp_sys_2::llama_sampler_init(llg_vtable(), Box::into_raw(ctx).cast::<c_void>())
     };
 
     if sampler.is_null() {

--- a/llama-cpp-2/src/llguidance_sampler.rs
+++ b/llama-cpp-2/src/llguidance_sampler.rs
@@ -4,10 +4,10 @@
 //! to enforce grammar constraints (JSON schema, regex, Lark, etc.) during token sampling.
 
 use std::ffi::c_void;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use llguidance::Matcher;
-use toktrie::{ApproximateTokEnv, TokEnv, TokRxInfo, TokTrie};
+use toktrie::{ApproximateTokEnv, TokRxInfo, TokTrie};
 
 use crate::model::LlamaModel;
 use crate::sampling::LlamaSampler;
@@ -15,23 +15,19 @@ use crate::token::LlamaToken;
 use crate::GrammarError;
 
 /// Internal state for the llguidance sampler.
-///
-/// A [`Matcher`] is self-contained (it owns its own tokenizer environment and parser
-/// state internally), so this is all the per-instance state the vtable callbacks need.
 struct LlgContext {
     matcher: Matcher,
+    tok_env: Arc<ApproximateTokEnv>,
+    grammar_kind: String,
+    grammar_data: String,
 }
 
 /// Build a [`toktrie::TokEnv`] from a [`LlamaModel`]'s vocabulary.
 ///
-/// Use this to construct your own `llguidance::ParserFactory` (with any slice regexes,
-/// inference capabilities, or other configuration llguidance supports) and, from it, a
-/// `llguidance::Matcher` to pass to [`create_llg_sampler_from_matcher`].
-///
 /// This mirrors the logic in upstream `llguidance.cpp` — for each token:
 /// - Try normal detokenize (special=false)
 /// - If empty, detokenize with special=true and prefix with 0xFF marker byte
-pub fn llguidance_build_tok_env(model: &LlamaModel) -> TokEnv {
+fn build_tok_env(model: &LlamaModel) -> Arc<ApproximateTokEnv> {
     let n_vocab = model.n_vocab().cast_unsigned();
     let tok_eos = {
         let eot = unsafe { llama_cpp_sys_2::llama_vocab_eot(model.vocab_ptr()) };
@@ -116,9 +112,15 @@ unsafe extern "C" fn llg_clone(
     let ctx = unsafe { &*(*smpl).ctx.cast::<LlgContext>() };
     let new_ctx = Box::new(LlgContext {
         matcher: ctx.matcher.deep_clone(),
+        tok_env: Arc::clone(&ctx.tok_env),
+        grammar_kind: ctx.grammar_kind.clone(),
+        grammar_data: ctx.grammar_data.clone(),
     });
     unsafe {
-        llama_cpp_sys_2::llama_sampler_init(llg_vtable(), Box::into_raw(new_ctx).cast::<c_void>())
+        llama_cpp_sys_2::llama_sampler_init(
+            &raw mut LLG_SAMPLER_I,
+            Box::into_raw(new_ctx).cast::<c_void>(),
+        )
     }
 }
 
@@ -129,62 +131,76 @@ unsafe extern "C" fn llg_free(smpl: *mut llama_cpp_sys_2::llama_sampler) {
     }
 }
 
-/// Returns a pointer to the llguidance sampler vtable.
-///
-/// The vtable's function pointers never change after construction, so a single instance
-/// is built lazily and shared by every llguidance sampler (and its clones) — only the
-/// per-instance `ctx` differs. This avoids a `static mut`.
-fn llg_vtable() -> *mut llama_cpp_sys_2::llama_sampler_i {
-    static VTABLE: OnceLock<Box<llama_cpp_sys_2::llama_sampler_i>> = OnceLock::new();
-    let vtable = VTABLE.get_or_init(|| {
-        Box::new(llama_cpp_sys_2::llama_sampler_i {
-            name: Some(llg_name),
-            accept: Some(llg_accept),
-            apply: Some(llg_apply),
-            reset: Some(llg_reset),
-            clone: Some(llg_clone),
-            free: Some(llg_free),
-            backend_init: None,
-            backend_accept: None,
-            backend_apply: None,
-            backend_set_input: None,
-        })
-    });
-    std::ptr::from_ref(vtable.as_ref()).cast_mut()
-}
-
-/// Wrap an already-built [`llguidance::Matcher`] into a [`LlamaSampler`].
-///
-/// This is the generic entry point: build a [`TokEnv`] via [`llguidance_build_tok_env`], your
-/// own `llguidance::ParserFactory` (with whatever slices, inference capabilities, or other
-/// llguidance configuration you need), parse your grammar into a `Matcher`, and hand it
-/// here. This function only adapts the `Matcher` into the `llama_sampler` vtable — it has
-/// no opinion on how the `Matcher` was built.
-pub(crate) fn create_llg_sampler_from_matcher(matcher: Matcher) -> LlamaSampler {
-    let ctx = Box::new(LlgContext { matcher });
-    let sampler = unsafe {
-        llama_cpp_sys_2::llama_sampler_init(llg_vtable(), Box::into_raw(ctx).cast::<c_void>())
-    };
-    LlamaSampler { sampler }
-}
+static mut LLG_SAMPLER_I: llama_cpp_sys_2::llama_sampler_i = llama_cpp_sys_2::llama_sampler_i {
+    name: Some(llg_name),
+    accept: Some(llg_accept),
+    apply: Some(llg_apply),
+    reset: Some(llg_reset),
+    clone: Some(llg_clone),
+    free: Some(llg_free),
+    backend_init: None,
+    backend_accept: None,
+    backend_apply: None,
+    backend_set_input: None,
+};
 
 /// Create an llguidance-based constrained decoding sampler.
 ///
 /// Uses `ParserFactory::new_simple`, which pre-builds a `SlicedBiasComputer` with the
-/// four general JSON regexes. For custom slice regexes or other `ParserFactory`
-/// configuration, build your own `llguidance::Matcher` (via [`llguidance_build_tok_env`] and the
-/// `llguidance` crate directly) and pass it to [`create_llg_sampler_from_matcher`] instead.
+/// four general JSON regexes. Prefer [`create_llg_sampler_with_slices`] when you know
+/// which token sub-sets are valid for your grammar — it can cut per-token constraint
+/// cost significantly on large vocabularies.
 pub(crate) fn create_llg_sampler(
     model: &LlamaModel,
     grammar_kind: &str,
     grammar_data: &str,
 ) -> Result<LlamaSampler, GrammarError> {
-    let tok_env = llguidance_build_tok_env(model);
+    let tok_env = build_tok_env(model);
     let tok_env_dyn: Arc<dyn toktrie::TokenizerEnv + Sync> = tok_env.clone();
 
     let factory = llguidance::ParserFactory::new_simple(&tok_env_dyn)
         .map_err(|_| GrammarError::NullGrammar)?;
 
+    finish_llg_sampler(tok_env, factory, grammar_kind, grammar_data)
+}
+
+/// Create an llguidance-based constrained decoding sampler with caller-supplied slice regexes.
+///
+/// `slices` is a list of regex strings. At startup, each regex is matched against the
+/// entire vocabulary and the matching tokens are stored in a pre-built bitmask. During
+/// inference, whenever only tokens matching a slice regex could be valid at the current
+/// position, llguidance uses that bitmask directly instead of walking the full vocabulary
+/// trie — cutting per-token cost significantly on large vocabularies.
+///
+/// Pass an empty slice list to disable the optimization entirely (falls back to a full
+/// trie walk on every token). Use [`llguidance::SlicedBiasComputer::general_slices`] for
+/// JSON-heavy grammars, or supply custom patterns suited to your output format
+/// (e.g. `[^<>{},:]+` for delimiter-bounded formats like Gemma-4 tool calls).
+pub(crate) fn create_llg_sampler_with_slices(
+    model: &LlamaModel,
+    grammar_kind: &str,
+    grammar_data: &str,
+    slices: &[String],
+) -> Result<LlamaSampler, GrammarError> {
+    let tok_env = build_tok_env(model);
+    let tok_env_dyn: Arc<dyn toktrie::TokenizerEnv + Sync> = tok_env.clone();
+
+    let factory = llguidance::ParserFactory::new(
+        &tok_env_dyn,
+        toktrie::InferenceCapabilities::default(),
+        slices,
+    )
+    .map_err(|_| GrammarError::NullGrammar)?;
+
+    finish_llg_sampler(tok_env, factory, grammar_kind, grammar_data)
+}
+
+fn finish_llg_sampler(
+    tok_env: Arc<ApproximateTokEnv>,
+    factory: llguidance::ParserFactory,
+    grammar_kind: &str,
+    grammar_data: &str,
+) -> Result<LlamaSampler, GrammarError> {
     let grammar = llguidance::api::TopLevelGrammar::from_tagged_str(grammar_kind, grammar_data)
         .map_err(|_| GrammarError::NullGrammar)?;
 
@@ -194,10 +210,18 @@ pub(crate) fn create_llg_sampler(
 
     let matcher = Matcher::new(Ok(parser));
 
-    let ctx = Box::new(LlgContext { matcher });
+    let ctx = Box::new(LlgContext {
+        matcher,
+        tok_env,
+        grammar_kind: grammar_kind.to_string(),
+        grammar_data: grammar_data.to_string(),
+    });
 
     let sampler = unsafe {
-        llama_cpp_sys_2::llama_sampler_init(llg_vtable(), Box::into_raw(ctx).cast::<c_void>())
+        llama_cpp_sys_2::llama_sampler_init(
+            &raw mut LLG_SAMPLER_I,
+            Box::into_raw(ctx).cast::<c_void>(),
+        )
     };
 
     if sampler.is_null() {

--- a/llama-cpp-2/src/llguidance_sampler.rs
+++ b/llama-cpp-2/src/llguidance_sampler.rs
@@ -145,6 +145,11 @@ static mut LLG_SAMPLER_I: llama_cpp_sys_2::llama_sampler_i = llama_cpp_sys_2::ll
 };
 
 /// Create an llguidance-based constrained decoding sampler.
+///
+/// Uses `ParserFactory::new_simple`, which pre-builds a `SlicedBiasComputer` with the
+/// four general JSON regexes. Prefer [`create_llg_sampler_with_slices`] when you know
+/// which token sub-sets are valid for your grammar — it can cut per-token constraint
+/// cost significantly on large vocabularies.
 pub(crate) fn create_llg_sampler(
     model: &LlamaModel,
     grammar_kind: &str,
@@ -156,6 +161,46 @@ pub(crate) fn create_llg_sampler(
     let factory = llguidance::ParserFactory::new_simple(&tok_env_dyn)
         .map_err(|_| GrammarError::NullGrammar)?;
 
+    finish_llg_sampler(tok_env, factory, grammar_kind, grammar_data)
+}
+
+/// Create an llguidance-based constrained decoding sampler with caller-supplied slice regexes.
+///
+/// `slices` is a list of regex strings. At startup, each regex is matched against the
+/// entire vocabulary and the matching tokens are stored in a pre-built bitmask. During
+/// inference, whenever only tokens matching a slice regex could be valid at the current
+/// position, llguidance uses that bitmask directly instead of walking the full vocabulary
+/// trie — cutting per-token cost significantly on large vocabularies.
+///
+/// Pass an empty slice list to disable the optimization entirely (falls back to a full
+/// trie walk on every token). Use [`llguidance::SlicedBiasComputer::general_slices`] for
+/// JSON-heavy grammars, or supply custom patterns suited to your output format
+/// (e.g. `[^<>{},:]+` for delimiter-bounded formats like Gemma-4 tool calls).
+pub(crate) fn create_llg_sampler_with_slices(
+    model: &LlamaModel,
+    grammar_kind: &str,
+    grammar_data: &str,
+    slices: &[String],
+) -> Result<LlamaSampler, GrammarError> {
+    let tok_env = build_tok_env(model);
+    let tok_env_dyn: Arc<dyn toktrie::TokenizerEnv + Sync> = tok_env.clone();
+
+    let factory = llguidance::ParserFactory::new(
+        &tok_env_dyn,
+        toktrie::InferenceCapabilities::default(),
+        slices,
+    )
+    .map_err(|_| GrammarError::NullGrammar)?;
+
+    finish_llg_sampler(tok_env, factory, grammar_kind, grammar_data)
+}
+
+fn finish_llg_sampler(
+    tok_env: Arc<ApproximateTokEnv>,
+    factory: llguidance::ParserFactory,
+    grammar_kind: &str,
+    grammar_data: &str,
+) -> Result<LlamaSampler, GrammarError> {
     let grammar = llguidance::api::TopLevelGrammar::from_tagged_str(grammar_kind, grammar_data)
         .map_err(|_| GrammarError::NullGrammar)?;
 

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -404,12 +404,6 @@ impl LlamaSampler {
     /// Uses the `llguidance` and `toktrie` Rust crates to enforce grammar constraints
     /// during token sampling. Supports JSON schema, regex, Lark, and other grammar types.
     ///
-    /// This covers the simple default case (llguidance's general-purpose JSON slices).
-    /// For custom slice regexes or other `ParserFactory` configuration, build your own
-    /// `llguidance::Matcher` using [`LlamaSampler::llguidance_tok_env`] and the
-    /// `llguidance` crate directly, then pass it to
-    /// [`LlamaSampler::llguidance_from_matcher`] instead.
-    ///
     /// # Errors
     ///
     /// Returns [`GrammarError`] if the grammar is invalid or the sampler cannot be initialized.
@@ -422,28 +416,29 @@ impl LlamaSampler {
         crate::llguidance_sampler::create_llg_sampler(model, grammar_kind, grammar_data)
     }
 
-    /// Builds the `toktrie` tokenizer environment for `model`.
+    /// `LLGuidance` sampler with caller-supplied slice regexes.
     ///
-    /// Use this to construct your own `llguidance::ParserFactory` (with any slice
-    /// regexes, inference capabilities, or other configuration llguidance supports) and,
-    /// from it, a `llguidance::Matcher` to pass to
-    /// [`LlamaSampler::llguidance_from_matcher`].
-    #[cfg(feature = "llguidance")]
-    #[must_use]
-    pub fn llguidance_tok_env(model: &LlamaModel) -> toktrie::TokEnv {
-        crate::llguidance_sampler::llguidance_build_tok_env(model)
-    }
-
-    /// Wraps an already-built `llguidance::Matcher` into a `LlamaSampler`.
+    /// Identical to [`llguidance`][Self::llguidance] but builds the `ParserFactory` with
+    /// the provided `slices` instead of the default JSON-focused regexes. Each regex
+    /// string describes a token sub-set; matching positions skip the full vocabulary
+    /// trie-walk. Pass an empty slice to disable the optimization entirely.
     ///
-    /// This is the generic entry point for any llguidance configuration this crate
-    /// doesn't special-case: build the `Matcher` yourself (via
-    /// [`LlamaSampler::llguidance_tok_env`] and the `llguidance` crate directly), and this
-    /// just adapts it into a sampler usable in a [`LlamaSampler::chain`].
+    /// # Errors
+    ///
+    /// Returns [`GrammarError`] if the grammar is invalid or the sampler cannot be initialized.
     #[cfg(feature = "llguidance")]
-    #[must_use]
-    pub fn llguidance_from_matcher(matcher: llguidance::Matcher) -> Self {
-        crate::llguidance_sampler::create_llg_sampler_from_matcher(matcher)
+    pub fn llguidance_with_slices(
+        model: &LlamaModel,
+        grammar_kind: &str,
+        grammar_data: &str,
+        slices: &[String],
+    ) -> Result<Self, GrammarError> {
+        crate::llguidance_sampler::create_llg_sampler_with_slices(
+            model,
+            grammar_kind,
+            grammar_data,
+            slices,
+        )
     }
 
     fn sanitize_grammar_strings(

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -404,6 +404,12 @@ impl LlamaSampler {
     /// Uses the `llguidance` and `toktrie` Rust crates to enforce grammar constraints
     /// during token sampling. Supports JSON schema, regex, Lark, and other grammar types.
     ///
+    /// This covers the simple default case (llguidance's general-purpose JSON slices).
+    /// For custom slice regexes or other `ParserFactory` configuration, build your own
+    /// `llguidance::Matcher` using [`LlamaSampler::llguidance_tok_env`] and the
+    /// `llguidance` crate directly, then pass it to
+    /// [`LlamaSampler::llguidance_from_matcher`] instead.
+    ///
     /// # Errors
     ///
     /// Returns [`GrammarError`] if the grammar is invalid or the sampler cannot be initialized.
@@ -416,29 +422,28 @@ impl LlamaSampler {
         crate::llguidance_sampler::create_llg_sampler(model, grammar_kind, grammar_data)
     }
 
-    /// `LLGuidance` sampler with caller-supplied slice regexes.
+    /// Builds the `toktrie` tokenizer environment for `model`.
     ///
-    /// Identical to [`llguidance`][Self::llguidance] but builds the `ParserFactory` with
-    /// the provided `slices` instead of the default JSON-focused regexes. Each regex
-    /// string describes a token sub-set; matching positions skip the full vocabulary
-    /// trie-walk. Pass an empty slice to disable the optimization entirely.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`GrammarError`] if the grammar is invalid or the sampler cannot be initialized.
+    /// Use this to construct your own `llguidance::ParserFactory` (with any slice
+    /// regexes, inference capabilities, or other configuration llguidance supports) and,
+    /// from it, a `llguidance::Matcher` to pass to
+    /// [`LlamaSampler::llguidance_from_matcher`].
     #[cfg(feature = "llguidance")]
-    pub fn llguidance_with_slices(
-        model: &LlamaModel,
-        grammar_kind: &str,
-        grammar_data: &str,
-        slices: &[String],
-    ) -> Result<Self, GrammarError> {
-        crate::llguidance_sampler::create_llg_sampler_with_slices(
-            model,
-            grammar_kind,
-            grammar_data,
-            slices,
-        )
+    #[must_use]
+    pub fn llguidance_tok_env(model: &LlamaModel) -> toktrie::TokEnv {
+        crate::llguidance_sampler::llguidance_build_tok_env(model)
+    }
+
+    /// Wraps an already-built `llguidance::Matcher` into a `LlamaSampler`.
+    ///
+    /// This is the generic entry point for any llguidance configuration this crate
+    /// doesn't special-case: build the `Matcher` yourself (via
+    /// [`LlamaSampler::llguidance_tok_env`] and the `llguidance` crate directly), and this
+    /// just adapts it into a sampler usable in a [`LlamaSampler::chain`].
+    #[cfg(feature = "llguidance")]
+    #[must_use]
+    pub fn llguidance_from_matcher(matcher: llguidance::Matcher) -> Self {
+        crate::llguidance_sampler::create_llg_sampler_from_matcher(matcher)
     }
 
     fn sanitize_grammar_strings(

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -416,6 +416,31 @@ impl LlamaSampler {
         crate::llguidance_sampler::create_llg_sampler(model, grammar_kind, grammar_data)
     }
 
+    /// `LLGuidance` sampler with caller-supplied slice regexes.
+    ///
+    /// Identical to [`llguidance`][Self::llguidance] but builds the `ParserFactory` with
+    /// the provided `slices` instead of the default JSON-focused regexes. Each regex
+    /// string describes a token sub-set; matching positions skip the full vocabulary
+    /// trie-walk. Pass an empty slice to disable the optimization entirely.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GrammarError`] if the grammar is invalid or the sampler cannot be initialized.
+    #[cfg(feature = "llguidance")]
+    pub fn llguidance_with_slices(
+        model: &LlamaModel,
+        grammar_kind: &str,
+        grammar_data: &str,
+        slices: &[String],
+    ) -> Result<Self, GrammarError> {
+        crate::llguidance_sampler::create_llg_sampler_with_slices(
+            model,
+            grammar_kind,
+            grammar_data,
+            slices,
+        )
+    }
+
     fn sanitize_grammar_strings(
         grammar_str: &str,
         grammar_root: &str,


### PR DESCRIPTION
### Summary

`LlamaSampler::llguidance` always builds its ParserFactory with `ParserFactory::new_simple`, which pre-computes bitmasks for four general JSON regexes. During inference, whenever only tokens in a slice could be valid, llguidance uses one of these pre-built bitmasks instead of walking the full vocabulary trie. However, this optimization only happens if the slice matches the token sub-set the grammar actually needs at that position.

For non-JSON grammars, the built-in JSON slices do essentially nothing and can waste a lot of set-up time. This PR exposes a variant that lets callers supply their own slice regexes.

### Changes

`llguidance_sampler.rs`
- Refactored the tail of `create_llg_sampler` into a private `finish_llg_sampler` helper shared by both functions
- Added `create_llg_sampler_with_slices(model, grammar_kind, grammar_data, slices)` which builds `ParserFactory::new(tok_env, InferenceCapabilities::default(), slices)` instead of `new_simple`

`sampling.rs`
- Added `LlamaSampler::llguidance_with_slices(model, grammar_kind, grammar_data, slices)` as the public API counterpart to the existing `LlamaSampler::llguidance`

### Usage
```
// JSON-heavy grammars — four generic JSON regexes
let slices = llguidance::earley::SlicedBiasComputer::general_slices();

// Delimiter-bounded formats (e.g. Gemma-4 tool calls)
let slices = vec![r"[^<>{},:]+".to_string()];

// Disable the optimization entirely
let slices: Vec<String> = vec![];

LlamaSampler::llguidance_with_slices(model, "lark", grammar, &slices)?
```
