### PR TITLE
feat(sys): allow overriding GGML_CPU_ARM_ARCH on Android arm64 (enable dotprod/i8mm)

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -815,6 +815,16 @@ fn main() {
             "arm64-v8a" => {
                 config.cflag("-march=armv8-a");
                 config.cxxflag("-march=armv8-a");
+                // Allow overriding ggml-cpu's Arm architecture, e.g. to enable the
+                // int8 dot-product / matmul kernels (`armv8.2-a+dotprod`,
+                // `armv8.6-a+i8mm`) on capable devices — Q4_K_M is several times
+                // faster with them. Opt-in via the `GGML_CPU_ARM_ARCH` env var so the
+                // default (`armv8-a`) is unchanged; this mirrors the Linux aarch64
+                // path, which already sets `GGML_CPU_ARM_ARCH`.
+                println!("cargo:rerun-if-env-changed=GGML_CPU_ARM_ARCH");
+                if let Ok(arch) = std::env::var("GGML_CPU_ARM_ARCH") {
+                    config.define("GGML_CPU_ARM_ARCH", &arch);
+                }
             }
             "armeabi-v7a" => {
                 config.cflag("-march=armv7-a");


### PR DESCRIPTION
## Summary

The Android `arm64-v8a` build hardcodes `-march=armv8-a`, so ggml-cpu's Arm
feature-detection for `dotprod` / `i8mm` fails and quantized inference (Q4_K_M and
friends) falls back to the scalar int8 path — several times slower than necessary on
essentially every modern Android SoC, which supports at least `dotprod` (armv8.2).

The **Linux aarch64** cross-compile path already exposes `GGML_CPU_ARM_ARCH`; Android had no equivalent knob. This adds one.

## Change

In the `"arm64-v8a"` arm of `llama-cpp-sys-2/build.rs`, read `GGML_CPU_ARM_ARCH` from the environment and pass it to ggml's CMake, which uses it directly (skipping the
`-mcpu=native` detection that doesn't apply to cross-compilation):

```rust
println!("cargo:rerun-if-env-changed=GGML_CPU_ARM_ARCH");
if let Ok(arch) = std::env::var("GGML_CPU_ARM_ARCH") {
    config.define("GGML_CPU_ARM_ARCH", &arch);
}
```

- **Opt-in, no behavior change:** with the env var unset, the default (`-march=armv8-a`)
  is unchanged — existing users are unaffected.
- Emits `rerun-if-env-changed` so toggling the value re-runs the build script.

## Usage

```bash
# dotprod — armv8.2, i.e. Cortex-A55/A78/X1/…, essentially all modern phones
GGML_CPU_ARM_ARCH=armv8.2-a+dotprod cargo ndk -t arm64-v8a build --release

# + i8mm (armv8.6 cores only)
GGML_CPU_ARM_ARCH=armv8.6-a+i8mm+dotprod cargo ndk -t arm64-v8a build --release
```

Choosing the arch is left to the caller because it's device-specific: building `+i8mm`
for a core that lacks it (e.g. anything armv8.2) will `SIGILL` at runtime.

## Verification

- Cross-compiled `aarch64-linux-android` (NDK r27c, API 24) with
  `GGML_CPU_ARM_ARCH=armv8.2-a+dotprod`: the resulting shared library contains
  **~900 `sdot`/`udot` instructions** (0 without the flag), confirming the int8
  dot-product kernels are compiled in.
- On a Pixel 7 Pro (Tensor G2), Q4_K_M (Ministral-3B) **prompt eval dropped ~3×**
  (≈175 s → ≈61 s for a ~1.4k-token prompt); token generation ~1.3–1.7× faster.
- Default build (env unset) is byte-identical to before.

## Notes

- Scope is intentionally minimal (env passthrough, arm64 only). A follow-up could add
  the same for `armeabi-v7a`, or default-detect, but keeping it opt-in avoids any risk
  of emitting instructions unsupported by a target device.
