### PR TITLE
Enable Sampler to backend offloading

### DIFF
--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -7,6 +7,7 @@ use std::slice;
 
 use crate::llama_batch::LlamaBatch;
 use crate::model::{LlamaLoraAdapter, LlamaModel};
+use crate::sampling::LlamaSampler;
 use crate::timing::LlamaTimings;
 use crate::token::data::LlamaTokenData;
 use crate::token::data_array::LlamaTokenDataArray;
@@ -28,6 +29,8 @@ pub struct LlamaContext<'a> {
     pub model: &'a LlamaModel,
     initialized_logits: Vec<i32>,
     embeddings_enabled: bool,
+    /// Backend samplers kept alive for the context's lifetime.
+    _backend_samplers: Vec<(i32, LlamaSampler)>,
 }
 
 impl Debug for LlamaContext<'_> {
@@ -49,6 +52,22 @@ impl<'model> LlamaContext<'model> {
             model: llama_model,
             initialized_logits: Vec::new(),
             embeddings_enabled,
+            _backend_samplers: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_samplers(
+        llama_model: &'model LlamaModel,
+        llama_context: NonNull<llama_cpp_sys_2::llama_context>,
+        embeddings_enabled: bool,
+        backend_samplers: Vec<(i32, LlamaSampler)>,
+    ) -> Self {
+        Self {
+            context: llama_context,
+            model: llama_model,
+            initialized_logits: Vec::new(),
+            embeddings_enabled,
+            _backend_samplers: backend_samplers,
         }
     }
 

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -382,6 +382,29 @@ impl<'model> LlamaContext<'model> {
         Ok(())
     }
 
+    /// Get the backend-sampled token at the given index.
+    ///
+    /// This is part of the experimental backend sampling API. Only usable
+    /// when the context was created with at least one `llama_sampler_seq_config`.
+    ///
+    /// Returns `None` if no token was sampled at the given index
+    /// (i.e. the C API returned `LLAMA_TOKEN_NULL`).
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - The token index, matching the order from the batch.
+    #[must_use]
+    pub fn sampled_token_ith(&self, i: i32) -> Option<LlamaToken> {
+        let token =
+            unsafe { llama_cpp_sys_2::llama_get_sampled_token_ith(self.context.as_ptr(), i) };
+        // LLAMA_TOKEN_NULL is #define'd as -1 in llama.h (not exposed by bindgen)
+        if token == -1 {
+            None
+        } else {
+            Some(LlamaToken(token))
+        }
+    }
+
     /// Print a breakdown of per-device memory use to the default logger.
     #[cfg(feature = "common")]
     pub fn print_memory_breakdown(&self) {

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -11,6 +11,7 @@ use crate::context::params::LlamaContextParams;
 use crate::context::LlamaContext;
 use crate::llama_backend::LlamaBackend;
 use crate::model::params::LlamaModelParams;
+use crate::sampling::LlamaSampler;
 use crate::token::LlamaToken;
 use crate::token_type::{LlamaTokenAttr, LlamaTokenAttrs};
 use crate::{
@@ -838,6 +839,63 @@ impl LlamaModel {
         let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
         Ok(LlamaContext::new(self, context, params.embeddings()))
+    }
+
+    /// Creates a new context with backend samplers attached for specific sequences.
+    ///
+    /// Ownership of the samplers is transferred to the context, ensuring they remain
+    /// alive for the context's lifetime. Only samplers that support backend execution
+    /// (greedy, dist, temp, top_k, top_p, min_p, logit_bias) will run on the backend.
+    ///
+    /// # Arguments
+    ///
+    /// * `params` - Context parameters
+    /// * `samplers` - Iterator of `(seq_id, sampler)` pairs where sampler must be a chain
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let sampler = LlamaSampler::chain([
+    ///     LlamaSampler::min_p(0.01, 64),
+    ///     LlamaSampler::temp(0.1),
+    ///     LlamaSampler::dist(42),
+    /// ], false);
+    ///
+    /// let ctx = model.new_context_with_samplers(
+    ///     &backend,
+    ///     ctx_params,
+    ///     [(0, sampler)],
+    /// )?;
+    /// ```
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new_context_with_samplers<'a>(
+        &'a self,
+        _: &LlamaBackend,
+        params: LlamaContextParams,
+        samplers: impl IntoIterator<Item = (i32, LlamaSampler)>,
+    ) -> Result<LlamaContext<'a>, LlamaContextLoadError> {
+        let samplers: Vec<_> = samplers.into_iter().collect();
+        let mut context_params = params.context_params;
+
+        let mut sampler_configs: Vec<llama_cpp_sys_2::llama_sampler_seq_config> = samplers
+            .iter()
+            .map(|(seq_id, sampler)| llama_cpp_sys_2::llama_sampler_seq_config {
+                seq_id: *seq_id,
+                sampler: sampler.sampler,
+            })
+            .collect();
+
+        if !sampler_configs.is_empty() {
+            context_params.samplers = sampler_configs.as_mut_ptr();
+            context_params.n_samplers = sampler_configs.len();
+        }
+
+        let context = unsafe {
+            llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
+        };
+        let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
+
+        Ok(LlamaContext::with_samplers(self, context, params.embeddings(), samplers))
     }
 
     /// Apply the models chat template to some messages.


### PR DESCRIPTION
Many of the standard sampling steps like `min-p` and `temp` have gpu optimized 
versions availible. Until now the rust bindings did not provide the right 
entrypoints to enable offloading for supported samplers (support may vary depending on the backend type as well!). Until now all samplers where run on the cpu side. Depending on the sampling chain topology this could lead to excessive pcie transfers. This is also highly model dependent, but especially the gemma model have a huge set of possible tokens -> many logics that need to cross the pcie bus. Even relativly small chains of samplers could deteriorate performance measurably!

This PR enables adding samplers at context creation time. More complex samplers 
like repetition penilties or grammars can not be run on any backend! 

Backend enabled samplers run on context decode. You can also only do partial steps on the backend, for example:

```rust,ignore
let sampler = LlamaSampler::chain([
    LlamaSampler::min_p(0.01, 64),
    LlamaSampler::temp(0.1),
], false);


let final_select = LlamaSampler::chain([
    // other cpu only samplers
    LlamaSampler::dist(),
], false);

let ctx = model.new_context_with_samplers(
    &backend,
    ctx_params,
    [(0, sampler)],
)?;

// Initialize prompt tokens and run

ctx.decode(prompt_tokens)?;

// sample next token
let token = final_select.sample(&mut ctx, -1);
```

I have successfully integrated this into my downstream project and am very pleased 
with the improved flexibility and performance. Have fun with it ;)

Cheers 
ju6ge