### PR TITLE
Windows: Link static and dynamic CRT libraries based on the debug profile instead of `debug_assertions`

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -1243,11 +1243,9 @@ fn main() {
     match target_os {
         TargetOs::Windows(WindowsVariant::Msvc) => {
             println!("cargo:rustc-link-lib=advapi32");
-            let crt_static = env::var("CARGO_CFG_TARGET_FEATURE")
-                .unwrap_or_default()
-                .contains("crt-static");
-            if cfg!(debug_assertions) {
-                if crt_static {
+            let lib_is_debug = profile.eq_ignore_ascii_case("debug");
+            if lib_is_debug {
+                if static_crt {
                     println!("cargo:rustc-link-lib=libcmtd");
                 } else {
                     println!("cargo:rustc-link-lib=dylib=msvcrtd");


### PR DESCRIPTION
On MSVC, `build.rs` picks the C runtime to link based on the build script's `debug_assertions`.

The problem is that llama.cpp itself is built with the release runtime by default (`LLAMA_LIB_PROFILE` defaults to `Release` therefore `/MD`). `cargo build` compiles the C++ against the release CRT but links `msvcrtd`, the debug one.

Additionally, rustc always links the release CRT on windows regardless of the profile, so the final binary ends up with two
runtimes loaded at once: `ucrtbase.dll` and `ucrtbased.dll`

This can lead to failures at runtime. I experienced this after linking llama next to another ggml library. It also shows up as an `_ITERATOR_DEBUG_LEVEL` `/failifmismatch` link error if anything else in the graph is release C++, same windows CRT breakage seen in #940.

The fix is to link the CRT that matches how llama.cpp was actually built, not the Rust profile:

```rust
let lib_is_debug = env::var("LLAMA_LIB_PROFILE")
    .map(|p| p.eq_ignore_ascii_case("debug"))
    .unwrap_or(false);
if lib_is_debug {
    if crt_static {
        println!("cargo:rustc-link-lib=libcmtd");
    } else {
        println!("cargo:rustc-link-lib=dylib=msvcrtd");
    }
}
```

This way default builds no longer pull in the debug CRT, so the binary has a single runtime. Building with `LLAMA_LIB_PROFILE=Debug` still links the debug CRT to match, so that path is unaffected.