### PR TITLE
Forward GGML_ env vars to CMake

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -625,6 +625,22 @@ fn main() {
         }
     }
 
+    // Also forward GGML_ environment variables as CMake cache entries, so a
+    // downstream can toggle any ggml build option without patching this build
+    // script. For example `GGML_CPU_REPACK=OFF` keeps Q4_0 weights in their
+    // original (mmap-friendly) layout instead of the runtime-repacked, anon-RAM
+    // one — needed when mmap-streaming a model that is larger than RAM.
+    //
+    // Precedence: options this build script sets explicitly further down
+    // (GGML_NATIVE, GGML_AVX*, GGML_CUDA, …) are defined after this loop and so
+    // win over any env value; only options left unset here are overridable.
+    for (key, value) in env::vars() {
+        if key.starts_with("GGML_") {
+            println!("cargo:rerun-if-env-changed={key}");
+            config.define(&key, &value);
+        }
+    }
+
     // extract the target-cpu config value, if specified
     let target_cpu = std::env::var("CARGO_ENCODED_RUSTFLAGS")
         .ok()


### PR DESCRIPTION
The build script already forwards `CMAKE_` prefixed environment variables to the CMake configure step. This does the same for `GGML_` prefixed ones, so you can flip any ggml build option from the environment without patching build.rs or forking the crate.

The case I ran into is `GGML_CPU_REPACK=OFF`. Repack converts Q4_0 weights into a runtime layout that lives in anonymous memory, which disables mmap and forces the whole model to be resident. That is fine when the model fits in RAM, but it makes it impossible to mmap stream a model that is larger than RAM, where you want the weights to stay file backed and page in on demand. Setting `GGML_CPU_REPACK=OFF` at build time solves that.

Options that build.rs sets explicitly (`GGML_NATIVE`, the `GGML_AVX*` flags, `GGML_CUDA` and so on) are defined after this loop, so they still take precedence. Nothing changes unless you set an option that was previously left unset. Each forwarded variable is registered with `rerun-if-env-changed`.
