### PR TITLE
Let the grammar samplers work without the `common` feature

### DIFF
--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -296,7 +296,6 @@ impl LlamaSampler {
     }
 
     /// Grammar sampler
-    #[cfg(feature = "common")]
     #[must_use]
     pub fn grammar(
         model: &LlamaModel,
@@ -306,8 +305,17 @@ impl LlamaSampler {
         let (grammar_str, grammar_root) =
             Self::sanitize_grammar_strings(grammar_str, grammar_root)?;
 
+        #[cfg(feature = "common")]
         let sampler = unsafe {
             llama_cpp_sys_2::llama_rs_sampler_init_grammar(
+                model.vocab_ptr(),
+                grammar_str.as_ptr(),
+                grammar_root.as_ptr(),
+            )
+        };
+        #[cfg(not(feature = "common"))]
+        let sampler = unsafe {
+            llama_cpp_sys_2::llama_sampler_init_grammar(
                 model.vocab_ptr(),
                 grammar_str.as_ptr(),
                 grammar_root.as_ptr(),
@@ -364,7 +372,12 @@ impl LlamaSampler {
     /// Trigger patterns are regular expressions matched from the start of the
     /// generation output. The grammar sampler will be fed content starting from
     /// the first match group.
-    #[cfg(feature = "common")]
+    ///
+    /// Without the `common` feature there is no C++ shim to catch exceptions,
+    /// and `llama.cpp` builds a `std::regex` from each trigger pattern, so an
+    /// invalid pattern aborts instead of returning
+    /// [`GrammarError::NullGrammar`]. An unparseable grammar is reported with a
+    /// null pointer either way.
     #[must_use]
     pub fn grammar_lazy_patterns(
         model: &LlamaModel,
@@ -380,8 +393,21 @@ impl LlamaSampler {
         let mut trigger_pattern_ptrs: Vec<*const c_char> =
             trigger_patterns.iter().map(|cs| cs.as_ptr()).collect();
 
+        #[cfg(feature = "common")]
         let sampler = unsafe {
             llama_cpp_sys_2::llama_rs_sampler_init_grammar_lazy_patterns(
+                model.vocab_ptr(),
+                grammar_str.as_ptr(),
+                grammar_root.as_ptr(),
+                trigger_pattern_ptrs.as_mut_ptr(),
+                trigger_pattern_ptrs.len(),
+                trigger_tokens.as_ptr().cast(),
+                trigger_tokens.len(),
+            )
+        };
+        #[cfg(not(feature = "common"))]
+        let sampler = unsafe {
+            llama_cpp_sys_2::llama_sampler_init_grammar_lazy_patterns(
                 model.vocab_ptr(),
                 grammar_str.as_ptr(),
                 grammar_root.as_ptr(),

--- a/llama-cpp-2/tests/grammar_without_common.rs
+++ b/llama-cpp-2/tests/grammar_without_common.rs
@@ -1,0 +1,72 @@
+//! Checks that the grammar samplers work when the `common` feature is off.
+//!
+//! Set `LLAMA_TEST_VOCAB_GGUF` to a GGUF file to run these.
+
+use std::sync::OnceLock;
+
+use llama_cpp_2::llama_backend::LlamaBackend;
+use llama_cpp_2::model::params::LlamaModelParams;
+use llama_cpp_2::model::LlamaModel;
+use llama_cpp_2::sampling::LlamaSampler;
+use llama_cpp_2::GrammarError;
+
+const GRAMMAR: &str = r#"root ::= "{" "\"a\"" ":" [0-9] "}""#;
+
+/// The vocabulary given by `LLAMA_TEST_VOCAB_GGUF`, or `None` to skip.
+///
+/// The backend can be started only one time in a process, and the tests share
+/// this process, so both the backend and the model are made one time here.
+/// `vocab_only` keeps the load cheap: a grammar needs the token table and no
+/// tensor data.
+fn model() -> Option<&'static LlamaModel> {
+    static MODEL: OnceLock<Option<(LlamaBackend, LlamaModel)>> = OnceLock::new();
+    MODEL
+        .get_or_init(|| {
+            let path = std::env::var("LLAMA_TEST_VOCAB_GGUF").ok()?;
+            let backend = LlamaBackend::init().unwrap();
+            let params = LlamaModelParams::default().with_vocab_only(true);
+            let model = LlamaModel::load_from_file(&backend, path, &params).unwrap();
+            Some((backend, model))
+        })
+        .as_ref()
+        .map(|(_backend, model)| model)
+}
+
+#[test]
+fn grammar_is_accepted() {
+    let Some(model) = model() else {
+        return;
+    };
+    assert!(LlamaSampler::grammar(model, GRAMMAR, "root").is_ok());
+}
+
+#[test]
+fn lazy_patterns_grammar_is_accepted() {
+    let Some(model) = model() else {
+        return;
+    };
+    let patterns = vec![r"\{".to_string()];
+    assert!(LlamaSampler::grammar_lazy_patterns(model, GRAMMAR, "root", &patterns, &[]).is_ok());
+}
+
+#[test]
+fn unparseable_grammar_gives_null_grammar() {
+    let Some(model) = model() else {
+        return;
+    };
+    assert_eq!(
+        LlamaSampler::grammar(model, "root ::= <<<", "root").err(),
+        Some(GrammarError::NullGrammar)
+    );
+}
+
+#[test]
+fn grammar_root_is_checked() {
+    let Some(model) = model() else {
+        return;
+    };
+    assert_eq!(
+        LlamaSampler::grammar(model, GRAMMAR, "missing").err(),
+        Some(GrammarError::RootNotFound)
+    );
+}


### PR DESCRIPTION
## What this changes

`LlamaSampler::grammar` and `LlamaSampler::grammar_lazy_patterns` no longer need the `common` feature.

## Why

The `common` feature builds the `common/` directory of llama.cpp. This adds approximately 14 MB to a static binary. A user who wants only grammar-constrained sampling had to accept all of that weight, or write the FFI call themselves.

The two functions do not need `common`. They call `llama_rs_*` shims, and those shims only put a try/catch around two functions:

- `llama_sampler_init_grammar`
- `llama_sampler_init_grammar_lazy_patterns`

Both are `LLAMA_API` in `include/llama.h`. They are in `libllama`, which every build links. The gate was not protecting a dependency on `libcommon`. The shims are in `wrapper_common.cpp` together with `llama_rs_fit_params` and `llama_rs_memory_breakdown_print`, which do need `libcommon`, and `build.rs` compiles that file as one unit under one feature flag. This is the reason for the gate.

I added the gate in #1015, so this is my own oversight.

## How

With the `common` feature, the calls still go through the shims. Without the feature, the calls go straight to `libllama`. `LlamaSampler::accept` already uses this shape.

The helper functions that these constructors use (`sanitize_grammar_strings`, `sanitize_trigger_patterns`) and the `GrammarError` type are not gated, so the second path needs no new types.

## Behaviour

The two paths give the same result for a grammar that llama.cpp cannot parse. llama.cpp catches those errors itself in `llama_grammar_init_impl` and reports the failure with a null pointer, which becomes `GrammarError::NullGrammar`.

There is one difference, and the documentation now records it. llama.cpp builds a `std::regex` from each trigger pattern in `llama-grammar.cpp`. An invalid pattern makes C++ throw, and without the feature there is no shim to catch it. Give only patterns that you know are valid, or turn the feature on. A caller with a constant pattern is safe.

## What stays gated

`grammar_lazy` keeps the `#[cfg(feature = "common")]` attribute. It takes trigger words instead of patterns, and it needs `regex_escape` from `common/common.h`. That is a true `libcommon` symbol.

`json_schema_to_grammar` also stays gated. It needs `libcommon` and `nlohmann/json`.

## Tests

`llama-cpp-2/tests/grammar_without_common.rs` verifies both feature states:

- a valid grammar is accepted
- a valid grammar with a trigger pattern is accepted
- a grammar that cannot be parsed gives `GrammarError::NullGrammar`
- a root symbol that is absent gives `GrammarError::RootNotFound`

The test needs a vocabulary. Set `LLAMA_TEST_VOCAB_GGUF` to any GGUF file, for example one of the vocabulary files in `llama-cpp-sys-2/llama.cpp/models/`. It loads with `vocab_only`, so the load is cheap. Without the variable the test does nothing and passes, so CI stays green.

Results with `ggml-vocab-gemma-4.gguf`, 4 passed in both states:

```
cargo test -p llama-cpp-2 --no-default-features --test grammar_without_common
cargo test -p llama-cpp-2 --no-default-features --features common --test grammar_without_common
```

`cargo clippy` and `cargo fmt --check` are clean for the two files that this pull request touches. Note that `cargo fmt --check` on a clean `main` already reports `examples/llguidance.rs`, `llama-cpp-2/src/llguidance_sampler.rs` and `llama-cpp-2/src/model.rs`. Those files are not part of this change and I did not touch them.
