### PR TITLE
fix: size embeddings reads by the LIVE pooling type, not n_embd

### DIFF
--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -140,7 +140,9 @@ impl<'model> LlamaContext<'model> {
     /// # Returns
     ///
     /// A slice containing the embeddings for the last decoded batch.
-    /// The size corresponds to the `n_embd` parameter of the context's model.
+    /// The size is the pooling-derived output width: `n_cls_out` for RANK,
+    /// `n_embd_out` otherwise — NOT `n_embd` (llama.h:1029 /
+    /// llama-context.cpp's extraction switch).
     ///
     /// # Errors
     ///
@@ -156,9 +158,6 @@ impl<'model> LlamaContext<'model> {
             return Err(EmbeddingsError::NotEnabled);
         }
 
-        let n_embd =
-            usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
-
         unsafe {
             let embedding = llama_cpp_sys_2::llama_get_embeddings_seq(self.context.as_ptr(), i);
 
@@ -166,7 +165,7 @@ impl<'model> LlamaContext<'model> {
             if embedding.is_null() {
                 Err(EmbeddingsError::NonePoolType)
             } else {
-                Ok(slice::from_raw_parts(embedding, n_embd))
+                Ok(slice::from_raw_parts(embedding, self.embeddings_out_len()))
             }
         }
     }
@@ -176,7 +175,9 @@ impl<'model> LlamaContext<'model> {
     /// # Returns
     ///
     /// A slice containing the embeddings for the last decoded batch of the given token.
-    /// The size corresponds to the `n_embd` parameter of the context's model.
+    /// The size is the pooling-derived output width: `n_cls_out` for RANK,
+    /// `n_embd_out` otherwise — NOT `n_embd` (llama.h:1029 /
+    /// llama-context.cpp's extraction switch).
     ///
     /// # Errors
     ///
@@ -192,17 +193,30 @@ impl<'model> LlamaContext<'model> {
             return Err(EmbeddingsError::NotEnabled);
         }
 
-        let n_embd =
-            usize::try_from(self.model.n_embd()).expect("n_embd does not fit into a usize");
-
         unsafe {
             let embedding = llama_cpp_sys_2::llama_get_embeddings_ith(self.context.as_ptr(), i);
             // Technically also possible whenever `i >= batch.n_tokens`, but no good way of checking `n_tokens` here.
             if embedding.is_null() {
                 Err(EmbeddingsError::LogitsNotEnabled)
             } else {
-                Ok(slice::from_raw_parts(embedding, n_embd))
+                Ok(slice::from_raw_parts(embedding, self.embeddings_out_len()))
             }
+        }
+    }
+
+    /// The correct output width for an embeddings read, keyed on the context's
+    /// LIVE pooling type rather than the model's `n_embd`.
+    ///
+    /// RANK reads return `float[n_cls_out]` (default 1) per llama.h:1029; every
+    /// other pooling mode extracts at `n_embd_out` per llama-context.cpp's
+    /// extraction switch (which diverges from `n_embd` whenever
+    /// `{arch}.embedding_length_out` is present).
+    fn embeddings_out_len(&self) -> usize {
+        let pooling = unsafe { llama_cpp_sys_2::llama_pooling_type(self.context.as_ptr()) };
+        if pooling == llama_cpp_sys_2::LLAMA_POOLING_TYPE_RANK {
+            usize::try_from(self.model.n_cls_out()).expect("n_cls_out does not fit into a usize")
+        } else {
+            usize::try_from(self.model.n_embd_out()).expect("n_embd_out does not fit into a usize")
         }
     }
 

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -589,6 +589,22 @@ impl LlamaModel {
         unsafe { llama_cpp_sys_2::llama_n_embd(self.model.as_ptr()) }
     }
 
+    /// The model's *output* embedding width (`n_embd_out`). This is the width
+    /// llama.cpp actually extracts embeddings at — `n_embd` and `n_embd_out`
+    /// diverge when `{arch}.embedding_length_out` is present (deepstack models
+    /// like qwen3vl). Returns a `c_int` for maximum compatibility.
+    #[must_use]
+    pub fn n_embd_out(&self) -> c_int {
+        unsafe { llama_cpp_sys_2::llama_model_n_embd_out(self.model.as_ptr()) }
+    }
+
+    /// The model's classification output width (`n_cls_out`, default 1) — the
+    /// width of a RANK-pooled embeddings read (llama.h:1029).
+    #[must_use]
+    pub fn n_cls_out(&self) -> u32 {
+        unsafe { llama_cpp_sys_2::llama_model_n_cls_out(self.model.as_ptr()) }
+    }
+
     /// Returns the total size of all the tensors in the model in bytes.
     pub fn size(&self) -> u64 {
         unsafe { llama_cpp_sys_2::llama_model_size(self.model.as_ptr()) }


### PR DESCRIPTION
## What

`LlamaContext::embeddings_seq_ith` and `embeddings_ith` build their return slice with `self.model.n_embd()`. That is the wrong length for every pooling mode:

| mode | correct width | why |
|---|---|---|
| `RANK` | `n_cls_out` (default 1) | llama.h:1029 sizes `llama_get_embeddings_seq` as `float[n_cls_out]` — the `n_embd`-wide read **over-reads** |
| `MEAN`/`CLS`/`LAST` | `n_embd_out` | llama-context.cpp's extraction switch resizes each `embd_seq` to `n_embd_out`, which diverges from `n_embd` whenever `{arch}.embedding_length_out` is present (deepstack models) |
| `NONE` (per-token) | `n_embd_out` | `get_embeddings_ith` returns `embd.data + j*n_embd_out`; the switch copies `n_tokens*n_embd_out` floats for NONE too |

Creating the over-long slice violates `slice::from_raw_parts`' validity contract (latent UB). The crate's own `examples/reranker` reads `[0]` of a RANK sequence and "works" only because the over-read lands in the same allocation.

## Fix

Size the read from the context's **LIVE pooling type** via a new `embeddings_out_len()` helper: `llama_model_n_cls_out` for RANK, `llama_model_n_embd_out` otherwise. Two new `LlamaModel` accessors (`n_embd_out()`, `n_cls_out()`) mirror the existing `n_embd()`.

## Notes

- Ground-truth verified against llama.cpp 0.1.150: `get_embeddings_ith` returns `embd.data + j*n_embd_out` and the extraction switch sizes `embd_seq` by pooling (`llama-context.cpp:1440-1480`); llama.h:1029 states the RANK width.
- This is a draft — CI is the first full compile of the change. omm (a downstream user of a vendored fork of this crate) carries the identical fix and its green build is the semantic proof.

Closes the S6-UB over-read behind omm's fork.