### PR TITLE
Bump llama.cpp submodule to b10200, port 3 breaking API changes

### DIFF
--- a/llama-cpp-2/src/model/params.rs
+++ b/llama-cpp-2/src/model/params.rs
@@ -142,6 +142,17 @@ impl Default for LlamaSplitMode {
 /// `llama_cpp_2::max_devices()`.
 pub const LLAMA_CPP_MAX_DEVICES: usize = 16;
 
+/// Combines the two independent `use_mmap`/`use_mlock` flags this crate's public
+/// API exposes into the single `load_mode` enum llama.cpp now stores them as.
+fn load_mode_from_flags(use_mmap: bool, use_mlock: bool) -> llama_cpp_sys_2::llama_load_mode {
+    match (use_mmap, use_mlock) {
+        (false, false) => llama_cpp_sys_2::LLAMA_LOAD_MODE_NONE,
+        (true, false) => llama_cpp_sys_2::LLAMA_LOAD_MODE_MMAP,
+        (false, true) => llama_cpp_sys_2::LLAMA_LOAD_MODE_MLOCK,
+        (true, true) => llama_cpp_sys_2::LLAMA_LOAD_MODE_MMAP_MLOCK,
+    }
+}
+
 /// A safe wrapper around `llama_model_params`.
 #[allow(clippy::module_name_repetitions)]
 pub struct LlamaModelParams {
@@ -159,8 +170,8 @@ impl Debug for LlamaModelParams {
             .field("n_gpu_layers", &self.params.n_gpu_layers)
             .field("main_gpu", &self.params.main_gpu)
             .field("vocab_only", &self.params.vocab_only)
-            .field("use_mmap", &self.params.use_mmap)
-            .field("use_mlock", &self.params.use_mlock)
+            .field("use_mmap", &self.use_mmap())
+            .field("use_mlock", &self.use_mlock())
             .field("split_mode", &self.split_mode())
             .field("devices", &self.devices)
             .field("kv_overrides", &"vec of kv_overrides")
@@ -436,15 +447,26 @@ impl LlamaModelParams {
     }
 
     /// use mmap if possible
+    ///
+    /// `use_mmap`/`use_mlock` were replaced by a single `load_mode` enum
+    /// (`args: refactor mlock/mmap/directio into load-mode`, #20834); this
+    /// getter decodes the combined mode back into the two independent flags
+    /// this crate's public API still exposes.
     #[must_use]
     pub fn use_mmap(&self) -> bool {
-        self.params.use_mmap
+        matches!(
+            self.params.load_mode,
+            llama_cpp_sys_2::LLAMA_LOAD_MODE_MMAP | llama_cpp_sys_2::LLAMA_LOAD_MODE_MMAP_MLOCK
+        )
     }
 
     /// force system to keep model in RAM
     #[must_use]
     pub fn use_mlock(&self) -> bool {
-        self.params.use_mlock
+        matches!(
+            self.params.load_mode,
+            llama_cpp_sys_2::LLAMA_LOAD_MODE_MLOCK | llama_cpp_sys_2::LLAMA_LOAD_MODE_MMAP_MLOCK
+        )
     }
 
     /// get the split mode
@@ -514,14 +536,14 @@ impl LlamaModelParams {
     /// sets `use_mmap`
     #[must_use]
     pub fn with_use_mmap(mut self, use_mmap: bool) -> Self {
-        self.params.use_mmap = use_mmap;
+        self.params.load_mode = load_mode_from_flags(use_mmap, self.use_mlock());
         self
     }
 
     /// sets `use_mlock`
     #[must_use]
     pub fn with_use_mlock(mut self, use_mlock: bool) -> Self {
-        self.params.use_mlock = use_mlock;
+        self.params.load_mode = load_mode_from_flags(self.use_mmap(), use_mlock);
         self
     }
 

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -291,6 +291,7 @@ impl MtmdContext {
         let text_cstring = CString::new(text.text)?;
         let input_text = llama_cpp_sys_2::mtmd_input_text {
             text: text_cstring.as_ptr(),
+            text_len: text_cstring.as_bytes().len(),
             add_special: text.add_special,
             parse_special: text.parse_special,
         };
@@ -477,7 +478,11 @@ impl MtmdBitmap {
         placeholder: bool,
     ) -> Result<Self, MtmdBitmapError> {
         let path_cstr = CString::new(path)?;
-        let bitmap = unsafe {
+        // This helper now returns a wrapper struct (bitmap + an optional video
+        // decoding context) instead of a bare pointer. `video_ctx` is only set
+        // when MTMD_VIDEO is enabled at compile time; this crate does not build
+        // with it on, so it is always null here and only the bitmap matters.
+        let wrapper = unsafe {
             llama_cpp_sys_2::mtmd_helper_bitmap_init_from_file(
                 ctx.context.as_ptr(),
                 path_cstr.as_ptr(),
@@ -485,7 +490,7 @@ impl MtmdBitmap {
             )
         };
 
-        let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        let bitmap = NonNull::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
         Ok(Self { bitmap })
     }
 
@@ -519,7 +524,9 @@ impl MtmdBitmap {
         data: &[u8],
         placeholder: bool,
     ) -> Result<Self, MtmdBitmapError> {
-        let bitmap = unsafe {
+        // See the comment in `from_file`: this returns a wrapper struct now, and
+        // `video_ctx` is always null since MTMD_VIDEO is not enabled in this build.
+        let wrapper = unsafe {
             llama_cpp_sys_2::mtmd_helper_bitmap_init_from_buf(
                 ctx.context.as_ptr(),
                 data.as_ptr(),
@@ -528,7 +535,7 @@ impl MtmdBitmap {
             )
         };
 
-        let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        let bitmap = NonNull::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
         Ok(Self { bitmap })
     }
 


### PR DESCRIPTION
llama_model_params.use_mlock/use_mmap became a single load_mode enum (upstream args: refactor mlock/mmap/directio into load-mode, #20834). use_mmap()/use_mlock()/with_use_mmap()/with_use_mlock() keep their exact public signature and default behaviour; they now read/write load_mode.

mtmd_input_text gained a required text_len field.

The mtmd bitmap-from-file/buffer helpers now return a mtmd_helper_bitmap_wrapper struct (bitmap + an optional video decoding context) instead of a bare pointer. This crate does not build with MTMD_VIDEO on, so video_ctx is always null; only .bitmap is used, with identical null-check semantics to before.

Verified: cargo check -p llama-cpp-2 --features mtmd is clean, and all params.rs doctests (including the use_mmap/use_mlock default assertions) pass unchanged.