### PR TITLE
sampling: catch C++ exceptions from sample/apply at the FFI boundary

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -431,6 +431,15 @@ pub enum SamplerAcceptError {
     FfiError(i32),
 }
 
+/// Failed to apply a sampler or sample a token.
+#[derive(Debug, thiserror::Error)]
+pub enum SamplerSampleError {
+    /// llama.cpp returned an error code (e.g. it threw a C++ exception, such as
+    /// a grammar masking every candidate, which was caught at the FFI boundary).
+    #[error("ffi error {0}")]
+    FfiError(i32),
+}
+
 /// Get the time in microseconds according to ggml
 ///
 /// ```

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -11,6 +11,8 @@ use crate::status_is_ok;
 use crate::token::data_array::LlamaTokenDataArray;
 use crate::token::logit_bias::LlamaLogitBias;
 use crate::token::LlamaToken;
+#[cfg(feature = "common")]
+use crate::SamplerSampleError;
 use crate::{GrammarError, SamplerAcceptError};
 
 /// A safe wrapper around `llama_sampler`.
@@ -33,6 +35,40 @@ impl LlamaSampler {
         };
 
         LlamaToken(token)
+    }
+
+    /// Try to sample and accept a token from the idx-th output of the last evaluation.
+    ///
+    /// Unlike [`Self::sample`], this returns an error instead of aborting the process
+    /// when llama.cpp throws during sampling. This happens, for example, when the
+    /// sampler chain leaves an empty candidate set (a grammar placed after a
+    /// truncation sampler such as top-k can mask every surviving token). The C++
+    /// exception would otherwise unwind across the FFI boundary, which Rust cannot
+    /// catch, killing the process.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SamplerSampleError::FfiError`] if llama.cpp throws during sampling.
+    #[cfg(feature = "common")]
+    pub fn try_sample(
+        &mut self,
+        ctx: &LlamaContext,
+        idx: i32,
+    ) -> Result<LlamaToken, SamplerSampleError> {
+        let mut token = 0;
+        let status = unsafe {
+            llama_cpp_sys_2::llama_rs_sampler_sample(
+                self.sampler,
+                ctx.context.as_ptr(),
+                idx,
+                &mut token,
+            )
+        };
+        if status_is_ok(status) {
+            Ok(LlamaToken(token))
+        } else {
+            Err(SamplerSampleError::FfiError(status))
+        }
     }
 
     /// Applies this sampler to a [`LlamaTokenDataArray`].

--- a/llama-cpp-2/src/token/data_array.rs
+++ b/llama-cpp-2/src/token/data_array.rs
@@ -129,6 +129,32 @@ impl LlamaTokenDataArray {
         }
     }
 
+    /// Modifies the data array by applying a sampler to it, returning an error
+    /// instead of aborting the process when llama.cpp throws during apply (for
+    /// example, a grammar that masks every remaining candidate). See
+    /// [`crate::sampling::LlamaSampler::try_sample`] for the same guarantee on
+    /// the combined sample path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::SamplerSampleError::FfiError`] if llama.cpp throws during apply.
+    #[cfg(feature = "common")]
+    pub fn try_apply_sampler(
+        &mut self,
+        sampler: &LlamaSampler,
+    ) -> Result<(), crate::SamplerSampleError> {
+        let status = unsafe {
+            self.modify_as_c_llama_token_data_array(|c_llama_token_data_array| {
+                llama_cpp_sys_2::llama_rs_sampler_apply(sampler.sampler, c_llama_token_data_array)
+            })
+        };
+        if crate::status_is_ok(status) {
+            Ok(())
+        } else {
+            Err(crate::SamplerSampleError::FfiError(status))
+        }
+    }
+
     /// Modifies the data array by applying a sampler to it
     #[must_use]
     pub fn with_sampler(mut self, sampler: &mut LlamaSampler) -> Self {

--- a/llama-cpp-sys-2/wrapper_common.cpp
+++ b/llama-cpp-sys-2/wrapper_common.cpp
@@ -124,6 +124,40 @@ extern "C" llama_rs_status llama_rs_sampler_accept(struct llama_sampler * sample
     }
 }
 
+extern "C" llama_rs_status llama_rs_sampler_sample(
+    struct llama_sampler * sampler,
+    struct llama_context * ctx,
+    int32_t idx,
+    llama_token * out_token) {
+    if (!sampler || !ctx || !out_token) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+    try {
+        *out_token = llama_sampler_sample(sampler, ctx, idx);
+        return LLAMA_RS_STATUS_OK;
+    } catch (const std::exception &) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    } catch (...) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    }
+}
+
+extern "C" llama_rs_status llama_rs_sampler_apply(
+    struct llama_sampler * sampler,
+    llama_token_data_array * cur_p) {
+    if (!sampler || !cur_p) {
+        return LLAMA_RS_STATUS_INVALID_ARGUMENT;
+    }
+    try {
+        llama_sampler_apply(sampler, cur_p);
+        return LLAMA_RS_STATUS_OK;
+    } catch (const std::exception &) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    } catch (...) {
+        return LLAMA_RS_STATUS_EXCEPTION;
+    }
+}
+
 // Thin pass-through to llama.cpp's common_fit_params (a C++ symbol in libcommon).
 // Returns common_params_fit_status as an int: 0 = success, 1 = failure, 2 = error.
 extern "C" int llama_rs_fit_params(

--- a/llama-cpp-sys-2/wrapper_common.h
+++ b/llama-cpp-sys-2/wrapper_common.h
@@ -46,6 +46,21 @@ struct llama_sampler * llama_rs_sampler_init_grammar_lazy_patterns(
 
 llama_rs_status llama_rs_sampler_accept(struct llama_sampler * sampler, llama_token token);
 
+// Wraps llama_sampler_sample in try/catch. llama.cpp can throw a C++ exception
+// during sampling (e.g. when a grammar masks every remaining candidate), which
+// would otherwise unwind across the FFI boundary and abort the process.
+llama_rs_status llama_rs_sampler_sample(
+    struct llama_sampler * sampler,
+    struct llama_context * ctx,
+    int32_t idx,
+    llama_token * out_token);
+
+// Wraps llama_sampler_apply in try/catch, for callers that apply a sampler to a
+// token data array directly instead of going through sample.
+llama_rs_status llama_rs_sampler_apply(
+    struct llama_sampler * sampler,
+    llama_token_data_array * cur_p);
+
 // Fit model/context params to device memory (wraps llama.cpp's common_fit_params).
 // Returns common_params_fit_status as an int: 0 = success, 1 = failure, 2 = error.
 int llama_rs_fit_params(


### PR DESCRIPTION
Closes #1082

llama.cpp can throw a C++ exception during sampling, for example when a grammar masks every remaining candidate (a grammar sampler placed after a truncation sampler such as top-k). The exception unwinds across the FFI boundary, Rust cannot catch foreign exceptions, and the process aborts:

```
fatal runtime error: Rust cannot catch foreign exceptions, aborting
```

#874 added try/catch wrappers for grammar construction and `accept`. This extends the same pattern to the sampling path:

- C++ shim (`wrapper_common.cpp/.h`): `llama_rs_sampler_sample` and `llama_rs_sampler_apply`, wrapping `llama_sampler_sample` / `llama_sampler_apply` in try/catch and returning `llama_rs_status`, mirroring the existing `llama_rs_sampler_accept`.
- Rust: `LlamaSampler::try_sample` and `LlamaTokenDataArray::try_apply_sampler`, returning a new `SamplerSampleError` instead of aborting. Gated on the `common` feature, like `try_accept`. The existing `sample`/`apply` are unchanged.

Verified on Windows (CPU build): the crate compiles, and a chain of `[top_k(1), grammar("root ::= \"unlikely\""), dist]` that aborted the process via `sample` now returns `Err(SamplerSampleError::FfiError(-3))` via `try_sample`, with the process surviving. This is the same failure real callers hit (nobodywho-ooo/nobodywho#421, whose generation loop uses `sample`).

No tests added, since the failure needs a loaded model and the crate's unit tests do not use one. Happy to add one under a feature/env gate if you prefer.
