### PR TITLE
Update the llama.cpp submodule to b10405 and port two API changes

### DIFF
--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -510,10 +510,6 @@ impl LlamaSampler {
         let sampler = unsafe {
             llama_cpp_sys_2::llama_sampler_init_dry(
                 model.vocab_ptr(),
-                model
-                    .n_ctx_train()
-                    .try_into()
-                    .expect("n_ctx_train exceeds i32::MAX"),
                 multiplier,
                 base,
                 allowed_length,
@@ -528,13 +524,16 @@ impl LlamaSampler {
     /// Penalizes tokens for being present in the context.
     ///
     /// Parameters:
-    /// - ``penalty_last_n``: last n tokens to penalize (0 = disable penalty, -1 = context size)
-    /// - ``penalty_repeat``: 1.0 = disabled
-    /// - ``penalty_freq``: 0.0 = disabled
-    /// - ``penalty_present``: 0.0 = disabled
+    /// - ``n_vocab``: [`LlamaModel::n_vocab`]
+    /// - ``penalty_last_n``: last n tokens to penalize (0 = disable penalty). Negative values are
+    ///   clamped to 0; they no longer select the context size.
+    /// - ``penalty_repeat``: must be > 0.0, 1.0 = disabled
+    /// - ``penalty_freq``: must be finite, 0.0 = disabled
+    /// - ``penalty_present``: must be finite, 0.0 = disabled
     #[allow(clippy::too_many_arguments)]
     #[must_use]
     pub fn penalties(
+        n_vocab: i32,
         penalty_last_n: i32,
         penalty_repeat: f32,
         penalty_freq: f32,
@@ -542,6 +541,7 @@ impl LlamaSampler {
     ) -> Self {
         let sampler = unsafe {
             llama_cpp_sys_2::llama_sampler_init_penalties(
+                n_vocab,
                 penalty_last_n,
                 penalty_repeat,
                 penalty_freq,


### PR DESCRIPTION
The submodule moves from b10200 to b10405. Two functions in the sampler API change in this range. The Rust wrappers now agree with them.

`llama_sampler_init_penalties` has a new first parameter, `n_vocab`. Upstream moves `n_vocab` from `llama_sampler_data` into the penalty sampler (ggml-org/llama.cpp#26520). `LlamaSampler::penalties` has the same new first parameter. This is a breaking change, and each caller must add `n_vocab` as the first argument. The `mirostat` and `logit_bias` wrappers already take `n_vocab` as the first parameter, so the `penalties` wrapper is now consistent with them.

`llama_sampler_init_dry` no longer has the `n_ctx_train` parameter. Upstream removes the full-context window from the samplers that keep a history (ggml-org/llama.cpp#26524). `LlamaSampler::dry` keeps its public signature. The wrapper no longer reads `n_ctx_train` from the model.

The same upstream change also changes the meaning of `penalty_last_n`. A negative value selected the context length. Upstream now sets a negative value to 0, and 0 disables the penalty. The documentation of `LlamaSampler::penalties` shows the new behaviour.

The reason for this update is the output of the DeepSeek-V4 models. The current submodule gives incorrect text for these models. A build from b10405 gives correct text for the same model, the same prompt and the same hardware.

`cargo build --workspace`, `cargo clippy` and `cargo test --features sampler` are clean with the new submodule.

One note on CI: `cargo fmt --check` already fails on `main` in `examples/llguidance.rs`, `llama-cpp-2/src/llguidance_sampler.rs` and `llama-cpp-2/src/model.rs`. This branch does not add to that list, and it does not correct it, because the files are not related to this change. Tell me if you prefer a separate pull request for the format.