### PR TITLE
Redirect logs from `mtmd` to `tracing`

### DIFF
--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -17,6 +17,7 @@
 use std::ffi::{c_char, CStr, CString, NulError};
 use std::fmt::Debug;
 use std::num::NonZeroI32;
+use std::sync::OnceLock;
 
 use crate::llama_batch::BatchAddError;
 use std::os::raw::c_int;
@@ -615,21 +616,42 @@ extern "C" fn logs_to_trace(
 pub fn send_logs_to_tracing(options: LogOptions) {
     // TODO: Reinitialize the state to support calling send_logs_to_tracing multiple times.
 
-    // We set up separate log states for llama.cpp and ggml to make sure that CONT logs between the two
-    // can't possibly interfere with each other. In other words, if llama.cpp emits a log without a trailing
-    // newline and calls a GGML function, the logs won't be weirdly intermixed and instead we'll llama.cpp logs
-    // will CONT previous llama.cpp logs and GGML logs will CONT previous ggml logs.
+    // We set up separate log states for each backend to make sure that CONT
+    // logs between them can't possibly interfere with each other.
+    //
+    // In other words, if llama.cpp emits a log without a trailing newline and
+    // calls a GGML function, the logs won't be weirdly intermixed and instead
+    // we'll llama.cpp logs will CONT previous llama.cpp logs and GGML logs
+    // will CONT previous ggml logs.
+    static LLAMA_STATE: OnceLock<Box<log::State>> = OnceLock::new();
+    #[cfg(feature = "mtmd")]
+    static MTMD_STATE: OnceLock<Box<log::State>> = OnceLock::new();
+    static GGML_STATE: OnceLock<Box<log::State>> = OnceLock::new();
+
     let llama_heap_state = Box::as_ref(
-        log::LLAMA_STATE
+        LLAMA_STATE
             .get_or_init(|| Box::new(log::State::new(log::Module::LlamaCpp, options.clone()))),
     ) as *const _;
+
+    #[cfg(feature = "mtmd")]
+    let mtmd_heap_state = Box::as_ref(
+        MTMD_STATE.get_or_init(|| Box::new(log::State::new(log::Module::Mtmd, options.clone()))),
+    ) as *const _;
+
     let ggml_heap_state = Box::as_ref(
-        log::GGML_STATE.get_or_init(|| Box::new(log::State::new(log::Module::GGML, options))),
+        GGML_STATE.get_or_init(|| Box::new(log::State::new(log::Module::GGML, options))),
     ) as *const _;
 
     unsafe {
-        // GGML has to be set after llama since setting llama sets ggml as well.
         llama_cpp_sys_2::llama_log_set(Some(logs_to_trace), llama_heap_state as *mut _);
+
+        // There is both `mtmd_log_set` and `mtmd_helper_log_set`. We use the
+        // helper, since we don't particularly want to differentiate these
+        // two, and the helper calls the normal `mtmd_log_set` as well.
+        #[cfg(feature = "mtmd")]
+        llama_cpp_sys_2::mtmd_helper_log_set(Some(logs_to_trace), mtmd_heap_state as *mut _);
+
+        // GGML has to be set after llama since setting llama logs sets ggml logs as well.
         llama_cpp_sys_2::ggml_log_set(Some(logs_to_trace), ggml_heap_state as *mut _);
     }
 }

--- a/llama-cpp-2/src/log.rs
+++ b/llama-cpp-2/src/log.rs
@@ -1,5 +1,4 @@
 use super::LogOptions;
-use std::sync::OnceLock;
 use tracing_core::{callsite, field, identify_callsite, Interest, Kind, Metadata};
 
 static FIELD_NAMES: &[&str] = &["message", "module"];
@@ -72,6 +71,8 @@ log_cs!(
 pub(super) enum Module {
     GGML,
     LlamaCpp,
+    /// Multimodal
+    Mtmd,
 }
 
 impl Module {
@@ -79,6 +80,7 @@ impl Module {
         match self {
             Module::GGML => "ggml",
             Module::LlamaCpp => "llama.cpp",
+            Module::Mtmd => "mtmd",
         }
     }
 }
@@ -276,9 +278,6 @@ impl State {
         tracing::dispatcher::get_default(|dispatcher| dispatcher.enabled(meta))
     }
 }
-
-pub(super) static LLAMA_STATE: OnceLock<Box<State>> = OnceLock::new();
-pub(super) static GGML_STATE: OnceLock<Box<State>> = OnceLock::new();
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
`mtmd.h` and `mtmd-helper.h` have their own logging statics, so we need to configure those in addition to the existing configuration for `llama.h` and `ggml.h`.