### PR TITLE
Fix building `llguidance` with newer `llama.cpp`

### DIFF
--- a/.github/workflows/llama-cpp-rs-check.yml
+++ b/.github/workflows/llama-cpp-rs-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Fmt
         run: cargo fmt --check
       - name: Test
-        run: cargo test --features sampler
+        run: cargo test --features sampler,mtmd,llguidance
       - name: Dry-Run Publishing
         run: RUST_BACKTRACE=1 cargo publish --workspace --verbose --dry-run
   arm64:
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build
-        run: cargo build --features sampler
+        run: cargo build --features sampler,mtmd,llguidance
   windows:
     name: Check that it builds on windows
     runs-on: windows-latest
@@ -82,6 +82,6 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build
-        run: cargo build --features sampler
+        run: cargo build --features sampler,mtmd,llguidance
       - name: Test
-        run: cargo test --features sampler
+        run: cargo test --features sampler,mtmd,llguidance

--- a/llama-cpp-2/src/llguidance_sampler.rs
+++ b/llama-cpp-2/src/llguidance_sampler.rs
@@ -165,6 +165,8 @@ static mut LLG_SAMPLER_I: llama_cpp_sys_2::llama_sampler_i = llama_cpp_sys_2::ll
     backend_accept: None,
     backend_apply: None,
     backend_set_input: None,
+    backend_reset: None,
+    copy_state: None,
 };
 
 /// Wraps an already-built [`llguidance::Matcher`] into a [`LlamaSampler`].


### PR DESCRIPTION
I think this was introduced in https://github.com/utilityai/llama-cpp-rs/pull/1097, the glue code for `llguidance` wasn't updated when `llama.cpp` was.

I've also updated the CI workflow to prevent issues like this in the future.