### PR TITLE
Simplify the lookup for `GGML_BACKENDS_DIR`

### DIFF
--- a/llama-cpp-2/build.rs
+++ b/llama-cpp-2/build.rs
@@ -1,5 +1,0 @@
-fn main() {
-    if let Ok(dir) = std::env::var("DEP_LLAMA_BACKENDS_DIR") {
-        println!("cargo:rustc-env=GGML_BACKENDS_DIR={}", dir);
-    }
-}

--- a/llama-cpp-2/src/llama_backend.rs
+++ b/llama-cpp-2/src/llama_backend.rs
@@ -180,12 +180,6 @@ impl Drop for LlamaBackend {
     }
 }
 
-/// Compile-time path to the built GGML backend modules directory.
-/// Populated by build.rs from `DEP_LLAMA_BACKENDS_DIR` (emitted by llama-cpp-sys-2).
-/// None on static builds or when the feature is disabled.
-#[cfg(feature = "dynamic-backends")]
-pub const BACKENDS_DIR: Option<&str> = option_env!("GGML_BACKENDS_DIR");
-
 /// Load GGML backend modules from the given directory.
 ///
 /// Call this before [`LlamaBackend::init`] to enable runtime hardware selection
@@ -203,7 +197,7 @@ pub fn load_backends_from_path(path: &std::path::Path) {
 /// that have not set `GGML_BACKENDS_DIR`).
 #[cfg(feature = "dynamic-backends")]
 pub fn load_backends() {
-    if let Some(dir) = BACKENDS_DIR {
+    if let Some(dir) = llama_cpp_sys_2::BACKENDS_DIR {
         load_backends_from_path(std::path::Path::new(dir));
     }
 }

--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -1064,6 +1064,13 @@ fn main() {
         config.define("GGML_CPU_ALL_VARIANTS", "ON");
         config.define("GGML_BACKEND_DIR", backends_dir.to_str().unwrap());
         // BUILD_SHARED_LIBS=ON is already set above via the dynamic-link feature.
+        println!(
+            "cargo:rustc-env=GGML_BACKENDS_DIR={}",
+            backends_dir.display()
+        );
+
+        // Expose backends dir to direct dependencies as `DEP_LLAMA_BACKENDS_DIR`.
+        println!("cargo:backends_dir={}", out_dir.join("backends").display());
     }
 
     // General
@@ -1073,10 +1080,6 @@ fn main() {
         .always_configure(false);
 
     let build_dir = config.build();
-
-    if cfg!(feature = "dynamic-backends") {
-        println!("cargo:backends_dir={}", out_dir.join("backends").display());
-    }
 
     // The CMake build installs a ggml package config. Tell the dependent crates where it
     // is, in the DEP_LLAMA_GGML_CMAKE_DIR variable. A dependent crate that also builds

--- a/llama-cpp-sys-2/src/lib.rs
+++ b/llama-cpp-sys-2/src/lib.rs
@@ -6,3 +6,8 @@
 #![allow(unpredictable_function_pointer_comparisons)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+/// Compile-time path to the built GGML backend modules directory.
+/// Populated by build.rs from `GGML_BACKENDS_DIR`.
+/// None on static builds or when the feature is disabled.
+pub const BACKENDS_DIR: Option<&str> = option_env!("GGML_BACKENDS_DIR");


### PR DESCRIPTION
Removes a build script, which should make compilation slightly faster.