### PR TITLE
feat(llama-cpp-sys-2): include ggml-webgpu backend source in package

### DIFF
--- a/llama-cpp-sys-2/Cargo.toml
+++ b/llama-cpp-sys-2/Cargo.toml
@@ -50,6 +50,7 @@ include = [
     "/llama.cpp/ggml/src/ggml-vulkan/**/*",
     "/llama.cpp/ggml/src/ggml-opencl/**/*",
     "/llama.cpp/ggml/src/ggml-hip/**/*",
+    "/llama.cpp/ggml/src/ggml-webgpu/**/*",
 
     "/llama.cpp/ggml/src/llamafile/sgemm.h",
     "/llama.cpp/ggml/src/llamafile/sgemm.cpp",


### PR DESCRIPTION
## Summary

The `ggml/CMakeLists.txt` in the vendored llama.cpp already carries the `option(GGML_WEBGPU "ggml: use WebGPU" OFF)` toggle (with `GGML_WEBGPU_DEBUG`, `GGML_WEBGPU_JSPI`, etc.), and `ggml-backend-reg.cpp` includes `ggml-webgpu.h`, but the implementation source directory (`ggml/src/ggml-webgpu/`) was missing from the crate's `include` allow-list in `llama-cpp-sys-2/Cargo.toml`. Flipping `GGML_WEBGPU=ON` on a published copy therefore produces a link failure because `add_subdirectory(ggml-webgpu)` can't find the directory.

This PR adds the `ggml-webgpu` tree to the include list, matching the per-backend pattern the other GPU backends (`metal`, `vulkan`, `cuda`, `hip`, `opencl`) already use.

## Details

Verified upstream `ggml/src/ggml-webgpu` at ggml-org/llama.cpp head contains:
- `CMakeLists.txt`
- `ggml-webgpu.cpp` (~4.7k LOC)
- `ggml-webgpu-shader-lib.hpp`
- `pre_wgsl.hpp`
- `wgsl-shaders/` (51 WGSL files including the full flash-attention family, subgroup-matrix `mul_mat`, `get_rows`, `cpy`, rope, `gated_delta_net`, `im2col`, `conv2d`, `argmax`, `argsort`, `glu`, `cumsum`, `concat`, `binary`)

## Test plan

- [ ] `cargo publish --dry-run -p llama-cpp-sys-2` includes the new tree in the packaged tarball.
- [ ] A published-tarball consumer setting `-DGGML_WEBGPU=ON` (via CMake args) can build past the previous "source directory missing" failure.

## Notes

This PR is deliberately minimal — just the packaging fix. It does not add a `webgpu` feature to `llama-cpp-sys-2` / `llama-cpp-2`, and does not add build.rs plumbing for GGML_WEBGPU. Those are follow-ons that depend on how consumers want Dawn / wgpu-native linkage handled (Emscripten uses `--use-port=emdawnwebgpu`; native builds want `find_package(Dawn REQUIRED)`; wasi-sdk targets want a header-only path). The consensus feature/build-system change is a bigger conversation; this PR just fixes the packaging oversight so those follow-ons have somewhere to hook.