### PR TITLE
Fix `LLamaBackend::init_numa`

### DIFF
--- a/llama-cpp-2/src/llama_backend.rs
+++ b/llama-cpp-2/src/llama_backend.rs
@@ -63,11 +63,12 @@ impl LlamaBackend {
     /// ```
     #[tracing::instrument(skip_all)]
     pub fn init_numa(strategy: NumaStrategy) -> crate::Result<LlamaBackend> {
-        Self::mark_init()?;
+        // Initialize backends first, then NUMA.
+        let this = Self::init()?;
         unsafe {
             llama_cpp_sys_2::llama_numa_init(llama_cpp_sys_2::ggml_numa_strategy::from(strategy));
         }
-        Ok(LlamaBackend {})
+        Ok(this)
     }
 
     /// Was the code built for a GPU backend & is a supported one available.


### PR DESCRIPTION
`llama_backend_init` should still be called if you wish to call `llama_numa_init`.

At least that's what the source seems to indicate:
https://github.com/ggml-org/llama.cpp/blob/557614e0296ff4a5b6f649737a65ae2076eea2fd/src/llama.cpp#L136-L146