### PR TITLE
Use trusted publishing to publish to crates.io

### DIFF
--- a/.github/workflows/publish-upon-release.yml
+++ b/.github/workflows/publish-upon-release.yml
@@ -8,17 +8,27 @@ on:
 
 permissions:
   contents: write
+  # Required to get the OIDC token that crates.io trusted publishing exchanges
+  # for a short-lived registry token.
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Must match the environment name in the crates.io trusted publisher config.
+    environment: release
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           submodules: recursive
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish crates for llama-cpp-sys-2
-        run: RUST_BACKTRACE=1 cargo publish --workspace --token ${{ secrets.CARGO_REGISTRY_TOKEN }} --verbose
+        run: RUST_BACKTRACE=1 cargo publish --workspace --verbose
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       # Trigger the 'update-toml-version' workflow
       - name: Dispatch Update TOML Version Event
         if: success()  # Ensure this runs only if the previous steps were successful


### PR DESCRIPTION
Replaces the long-lived `CARGO_REGISTRY_TOKEN` secret with crates.io trusted publishing.

## Changes

- Added `id-token: write`, so the job can get a GitHub OIDC token.
- Added a `rust-lang/crates-io-auth-action` step, pinned to the v1.0.5 SHA. It matches the way the other actions in this repo are pinned. The step returns a token that expires in 30 minutes.
- `cargo publish` now reads `CARGO_REGISTRY_TOKEN` from that step. `secrets.CARGO_REGISTRY_TOKEN` is gone.
- The job runs in a `release` environment.

## Required before you merge and release

**1. Create the `release` environment.** Settings -> Environments -> New environment, named exactly `release`. Add **Required reviewers**, or the environment gates nothing. It then only scopes the OIDC claim.

**2. Add a trusted publisher on crates.io.** Do this for **both** crates, because `cargo publish --workspace` publishes both. Crate page -> Settings -> Trusted Publishing -> Add:

| Field | Value |
|---|---|
| Repository owner | `utilityai` |
| Repository name | `llama-cpp-rs` |
| Workflow filename | `publish-upon-release.yml` |
| Environment name | `release` |

The environment name must match on both sides. A mismatch stays silent until a release fails.

**3. Keep the old secret until one release succeeds.** Then delete the GitHub secret and revoke the API token. If you revoke first and the crates.io config has an error, the release fails with no fallback.

## Notes

- Required reviewers stop hands-free releases. Someone must approve the job. That is the tradeoff.
- After the first good release, you can **enforce** trusted publishing per crate on crates.io. Token publishing is then refused, so a leaked token cannot publish.
- Unrelated pre-existing bug, not fixed here: in `on:`, `workflow_dispatch:` is indented under `release:`. It is a key of the release event, not a separate trigger. Manual runs are probably not possible. I left it alone, because a fix lets anyone with write access start a publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YQ6xjvaKXKWS9Q9iNaMFP