### PR TITLE
Soundness: Fix invalid mutation behind `&`

### DIFF
--- a/examples/llguidance.rs
+++ b/examples/llguidance.rs
@@ -75,7 +75,7 @@ fn main() {
     std::io::stdout().flush().unwrap();
 
     while n_cur <= 128 {
-        let token = sampler.sample(&ctx, batch.n_tokens() - 1);
+        let token = sampler.sample(&mut ctx, batch.n_tokens() - 1);
 
         if token == model.token_eos() {
             break;

--- a/examples/mtmd/src/mtmd.rs
+++ b/examples/mtmd/src/mtmd.rs
@@ -181,7 +181,7 @@ impl<'a> MtmdCliContext<'a> {
         // Clear bitmaps after tokenization
         self.bitmaps.clear();
 
-        self.n_past = chunks.eval_chunks(&self.mtmd_ctx, context, 0, 0, batch_size, true)?;
+        self.n_past = chunks.eval_chunks(&mut self.mtmd_ctx, context, 0, 0, batch_size, true)?;
         Ok(())
     }
 

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -329,7 +329,7 @@ either reduce n_len or increase n_ctx"
     while n_cur <= n_len {
         // sample the next token
         {
-            let token = sampler.sample(&ctx, batch.n_tokens() - 1);
+            let token = sampler.sample(&mut ctx, batch.n_tokens() - 1);
 
             sampler.accept(token);
 

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -58,7 +58,7 @@ fn main() {
     while n_cur <= n_len {
         // sample the next token
         {
-            let token = sampler.sample(&ctx, batch.n_tokens() - 1);
+            let token = sampler.sample(&mut ctx, batch.n_tokens() - 1);
 
             sampler.accept(token);
 

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -2,11 +2,11 @@
 
 use std::fmt::{Debug, Formatter};
 use std::num::NonZeroI32;
-use std::ptr::NonNull;
 use std::slice;
 
 use crate::llama_batch::LlamaBatch;
 use crate::model::{LlamaLoraAdapter, LlamaModel};
+use crate::ptr::Ptr;
 use crate::sampling::LlamaSampler;
 use crate::timing::LlamaTimings;
 use crate::token::data::LlamaTokenData;
@@ -24,7 +24,7 @@ pub mod session;
 /// Safe wrapper around `llama_context`.
 #[allow(clippy::module_name_repetitions)]
 pub struct LlamaContext<'a> {
-    pub(crate) context: NonNull<llama_cpp_sys_2::llama_context>,
+    pub(crate) context: Ptr<llama_cpp_sys_2::llama_context>,
     /// a reference to the contexts model.
     pub model: &'a LlamaModel,
     initialized_logits: Vec<i32>,
@@ -44,7 +44,7 @@ impl Debug for LlamaContext<'_> {
 impl<'model> LlamaContext<'model> {
     pub(crate) fn new(
         llama_model: &'model LlamaModel,
-        llama_context: NonNull<llama_cpp_sys_2::llama_context>,
+        llama_context: Ptr<llama_cpp_sys_2::llama_context>,
         embeddings_enabled: bool,
     ) -> Self {
         Self {
@@ -58,7 +58,7 @@ impl<'model> LlamaContext<'model> {
 
     pub(crate) fn with_samplers(
         llama_model: &'model LlamaModel,
-        llama_context: NonNull<llama_cpp_sys_2::llama_context>,
+        llama_context: Ptr<llama_cpp_sys_2::llama_context>,
         embeddings_enabled: bool,
         backend_samplers: Vec<(i32, LlamaSampler)>,
     ) -> Self {

--- a/llama-cpp-2/src/context.rs
+++ b/llama-cpp-2/src/context.rs
@@ -100,7 +100,7 @@ impl<'model> LlamaContext<'model> {
     /// - the returned [`std::ffi::c_int`] from llama-cpp does not fit into a i32 (this should never happen on most systems)
     pub fn decode(&mut self, batch: &mut LlamaBatch) -> Result<(), DecodeError> {
         let result =
-            unsafe { llama_cpp_sys_2::llama_decode(self.context.as_ptr(), batch.llama_batch) };
+            unsafe { llama_cpp_sys_2::llama_decode(self.context.as_mut_ptr(), batch.llama_batch) };
 
         match NonZeroI32::new(result) {
             None => {
@@ -123,7 +123,7 @@ impl<'model> LlamaContext<'model> {
     /// - the returned [`std::ffi::c_int`] from llama-cpp does not fit into a i32 (this should never happen on most systems)
     pub fn encode(&mut self, batch: &mut LlamaBatch) -> Result<(), EncodeError> {
         let result =
-            unsafe { llama_cpp_sys_2::llama_encode(self.context.as_ptr(), batch.llama_batch) };
+            unsafe { llama_cpp_sys_2::llama_encode(self.context.as_mut_ptr(), batch.llama_batch) };
 
         match NonZeroI32::new(result) {
             None => {
@@ -153,13 +153,13 @@ impl<'model> LlamaContext<'model> {
     /// # Panics
     ///
     /// * `n_embd` does not fit into a usize
-    pub fn embeddings_seq_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
+    pub fn embeddings_seq_ith(&mut self, i: i32) -> Result<&[f32], EmbeddingsError> {
         if !self.embeddings_enabled {
             return Err(EmbeddingsError::NotEnabled);
         }
 
         unsafe {
-            let embedding = llama_cpp_sys_2::llama_get_embeddings_seq(self.context.as_ptr(), i);
+            let embedding = llama_cpp_sys_2::llama_get_embeddings_seq(self.context.as_mut_ptr(), i);
 
             // Technically also possible whenever `i >= max(batch.n_seq)`, but can't check that here.
             if embedding.is_null() {
@@ -188,13 +188,13 @@ impl<'model> LlamaContext<'model> {
     /// # Panics
     ///
     /// * `n_embd` does not fit into a usize
-    pub fn embeddings_ith(&self, i: i32) -> Result<&[f32], EmbeddingsError> {
+    pub fn embeddings_ith(&mut self, i: i32) -> Result<&[f32], EmbeddingsError> {
         if !self.embeddings_enabled {
             return Err(EmbeddingsError::NotEnabled);
         }
 
         unsafe {
-            let embedding = llama_cpp_sys_2::llama_get_embeddings_ith(self.context.as_ptr(), i);
+            let embedding = llama_cpp_sys_2::llama_get_embeddings_ith(self.context.as_mut_ptr(), i);
             // Technically also possible whenever `i >= batch.n_tokens`, but no good way of checking `n_tokens` here.
             if embedding.is_null() {
                 Err(EmbeddingsError::LogitsNotEnabled)
@@ -229,7 +229,7 @@ impl<'model> LlamaContext<'model> {
     /// # Panics
     ///
     /// - underlying logits data is null
-    pub fn candidates(&self) -> impl Iterator<Item = LlamaTokenData> + '_ {
+    pub fn candidates(&mut self) -> impl Iterator<Item = LlamaTokenData> + '_ {
         (0_i32..).zip(self.get_logits()).map(|(i, logit)| {
             let token = LlamaToken::new(i);
             LlamaTokenData::new(token, *logit, 0_f32)
@@ -247,7 +247,7 @@ impl<'model> LlamaContext<'model> {
     ///
     /// - underlying logits data is null
     #[must_use]
-    pub fn token_data_array(&self) -> LlamaTokenDataArray {
+    pub fn token_data_array(&mut self) -> LlamaTokenDataArray {
         LlamaTokenDataArray::from_iter(self.candidates(), false)
     }
 
@@ -267,8 +267,8 @@ impl<'model> LlamaContext<'model> {
     /// - `n_vocab` does not fit into a usize
     /// - token data returned is null
     #[must_use]
-    pub fn get_logits(&self) -> &[f32] {
-        let data = unsafe { llama_cpp_sys_2::llama_get_logits(self.context.as_ptr()) };
+    pub fn get_logits(&mut self) -> &[f32] {
+        let data = unsafe { llama_cpp_sys_2::llama_get_logits(self.context.as_mut_ptr()) };
         assert!(!data.is_null(), "logits data for last token is null");
         let len = usize::try_from(self.model.n_vocab()).expect("n_vocab does not fit into a usize");
 
@@ -280,7 +280,7 @@ impl<'model> LlamaContext<'model> {
     /// # Panics
     ///
     /// - logit `i` is not initialized.
-    pub fn candidates_ith(&self, i: i32) -> impl Iterator<Item = LlamaTokenData> + '_ {
+    pub fn candidates_ith(&mut self, i: i32) -> impl Iterator<Item = LlamaTokenData> + '_ {
         (0_i32..).zip(self.get_logits_ith(i)).map(|(i, logit)| {
             let token = LlamaToken::new(i);
             LlamaTokenData::new(token, *logit, 0_f32)
@@ -298,7 +298,7 @@ impl<'model> LlamaContext<'model> {
     ///
     /// - logit `i` is not initialized.
     #[must_use]
-    pub fn token_data_array_ith(&self, i: i32) -> LlamaTokenDataArray {
+    pub fn token_data_array_ith(&mut self, i: i32) -> LlamaTokenDataArray {
         LlamaTokenDataArray::from_iter(self.candidates_ith(i), false)
     }
 
@@ -310,7 +310,7 @@ impl<'model> LlamaContext<'model> {
     /// - `n_vocab` does not fit into a usize
     /// - logit `i` is not initialized.
     #[must_use]
-    pub fn get_logits_ith(&self, i: i32) -> &[f32] {
+    pub fn get_logits_ith(&mut self, i: i32) -> &[f32] {
         assert!(
             self.initialized_logits.contains(&i),
             "logit {i} is not initialized. only {:?} is",
@@ -323,7 +323,7 @@ impl<'model> LlamaContext<'model> {
             i
         );
 
-        let data = unsafe { llama_cpp_sys_2::llama_get_logits_ith(self.context.as_ptr(), i) };
+        let data = unsafe { llama_cpp_sys_2::llama_get_logits_ith(self.context.as_mut_ptr(), i) };
         let len = usize::try_from(self.model.n_vocab()).expect("n_vocab does not fit into a usize");
 
         unsafe { slice::from_raw_parts(data, len) }
@@ -331,7 +331,7 @@ impl<'model> LlamaContext<'model> {
 
     /// Reset the timings for the context.
     pub fn reset_timings(&mut self) {
-        unsafe { llama_cpp_sys_2::llama_perf_context_reset(self.context.as_ptr()) }
+        unsafe { llama_cpp_sys_2::llama_perf_context_reset(self.context.as_mut_ptr()) }
     }
 
     /// Returns the timings for the context.
@@ -346,15 +346,15 @@ impl<'model> LlamaContext<'model> {
     ///
     /// See [`LlamaLoraAdapterSetError`] for more information.
     pub fn lora_adapter_set(
-        &self,
+        &mut self,
         adapter: &mut LlamaLoraAdapter,
         scale: f32,
     ) -> Result<(), LlamaLoraAdapterSetError> {
-        let mut adapters = [adapter.lora_adapter.as_ptr()];
+        let mut adapters = [adapter.lora_adapter.as_mut_ptr()];
         let mut scales = [scale];
         let err_code = unsafe {
             llama_cpp_sys_2::llama_set_adapters_lora(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 adapters.as_mut_ptr(),
                 1,
                 scales.as_mut_ptr(),
@@ -377,12 +377,12 @@ impl<'model> LlamaContext<'model> {
     ///
     /// See [`LlamaLoraAdapterRemoveError`] for more information.
     pub fn lora_adapter_remove(
-        &self,
+        &mut self,
         _adapter: &mut LlamaLoraAdapter,
     ) -> Result<(), LlamaLoraAdapterRemoveError> {
         let err_code = unsafe {
             llama_cpp_sys_2::llama_set_adapters_lora(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 std::ptr::null_mut(),
                 0,
                 std::ptr::null_mut(),
@@ -408,9 +408,9 @@ impl<'model> LlamaContext<'model> {
     ///
     /// * `i` - The token index, matching the order from the batch.
     #[must_use]
-    pub fn sampled_token_ith(&self, i: i32) -> Option<LlamaToken> {
+    pub fn sampled_token_ith(&mut self, i: i32) -> Option<LlamaToken> {
         let token =
-            unsafe { llama_cpp_sys_2::llama_get_sampled_token_ith(self.context.as_ptr(), i) };
+            unsafe { llama_cpp_sys_2::llama_get_sampled_token_ith(self.context.as_mut_ptr(), i) };
         // LLAMA_TOKEN_NULL is #define'd as -1 in llama.h (not exposed by bindgen)
         if token == -1 {
             None
@@ -428,6 +428,6 @@ impl<'model> LlamaContext<'model> {
 
 impl Drop for LlamaContext<'_> {
     fn drop(&mut self) {
-        unsafe { llama_cpp_sys_2::llama_free(self.context.as_ptr()) }
+        unsafe { llama_cpp_sys_2::llama_free(self.context.as_mut_ptr()) }
     }
 }

--- a/llama-cpp-2/src/context/session.rs
+++ b/llama-cpp-2/src/context/session.rs
@@ -155,7 +155,7 @@ impl LlamaContext<'_> {
     /// Fails if the path is not a valid utf8, is not a valid c string, or llama.cpp fails to save the session file.
     #[deprecated(since = "0.1.136", note = "Use `state_save_file` instead")]
     pub fn save_session_file(
-        &self,
+        &mut self,
         path_session: impl AsRef<Path>,
         tokens: &[LlamaToken],
     ) -> Result<(), SaveSessionError> {
@@ -168,7 +168,7 @@ impl LlamaContext<'_> {
 
         if unsafe {
             llama_cpp_sys_2::llama_save_session_file(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 cstr.as_ptr(),
                 tokens.as_ptr().cast::<llama_cpp_sys_2::llama_token>(),
                 tokens.len(),
@@ -211,7 +211,7 @@ impl LlamaContext<'_> {
 
         let load_session_success = unsafe {
             llama_cpp_sys_2::llama_load_session_file(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 cstr.as_ptr(),
                 tokens_out,
                 max_tokens,
@@ -247,7 +247,7 @@ impl LlamaContext<'_> {
     /// Fails if the path is not a valid utf8, is not a valid c string, or llama.cpp fails to save
     /// the state file.
     pub fn state_save_file(
-        &self,
+        &mut self,
         path_session: impl AsRef<Path>,
         tokens: &[LlamaToken],
     ) -> Result<(), SaveSessionError> {
@@ -260,7 +260,7 @@ impl LlamaContext<'_> {
 
         if unsafe {
             llama_cpp_sys_2::llama_state_save_file(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 cstr.as_ptr(),
                 tokens.as_ptr().cast::<llama_cpp_sys_2::llama_token>(),
                 tokens.len(),
@@ -309,7 +309,7 @@ impl LlamaContext<'_> {
 
         let success = unsafe {
             llama_cpp_sys_2::llama_state_load_file(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 cstr.as_ptr(),
                 tokens_out,
                 max_tokens,
@@ -350,7 +350,7 @@ impl LlamaContext<'_> {
     ///
     /// The number of bytes written on success.
     pub fn state_seq_save_file(
-        &self,
+        &mut self,
         filepath: impl AsRef<Path>,
         seq_id: i32,
         tokens: &[LlamaToken],
@@ -364,7 +364,7 @@ impl LlamaContext<'_> {
 
         let bytes_written = unsafe {
             llama_cpp_sys_2::llama_state_seq_save_file(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 cstr.as_ptr(),
                 seq_id,
                 tokens.as_ptr().cast::<llama_cpp_sys_2::llama_token>(),
@@ -418,7 +418,7 @@ impl LlamaContext<'_> {
 
         let bytes_read = unsafe {
             llama_cpp_sys_2::llama_state_seq_load_file(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 cstr.as_ptr(),
                 dest_seq_id,
                 tokens_out,
@@ -446,8 +446,8 @@ impl LlamaContext<'_> {
     /// Returns the maximum size in bytes of the state (rng, logits, embedding
     /// and `kv_cache`) - will often be smaller after compacting tokens
     #[must_use]
-    pub fn get_state_size(&self) -> usize {
-        unsafe { llama_cpp_sys_2::llama_get_state_size(self.context.as_ptr()) }
+    pub fn get_state_size(&mut self) -> usize {
+        unsafe { llama_cpp_sys_2::llama_get_state_size(self.context.as_mut_ptr()) }
     }
 
     /// Copies the state to the specified destination address.
@@ -457,8 +457,8 @@ impl LlamaContext<'_> {
     /// # Safety
     ///
     /// Destination needs to have allocated enough memory.
-    pub unsafe fn copy_state_data(&self, dest: *mut u8) -> usize {
-        unsafe { llama_cpp_sys_2::llama_copy_state_data(self.context.as_ptr(), dest) }
+    pub unsafe fn copy_state_data(&mut self, dest: *mut u8) -> usize {
+        unsafe { llama_cpp_sys_2::llama_copy_state_data(self.context.as_mut_ptr(), dest) }
     }
 
     /// Set the state reading from the specified address
@@ -468,7 +468,7 @@ impl LlamaContext<'_> {
     ///
     /// help wanted: not entirely sure what the safety requirements are here.
     pub unsafe fn set_state_data(&mut self, src: &[u8]) -> usize {
-        unsafe { llama_cpp_sys_2::llama_set_state_data(self.context.as_ptr(), src.as_ptr()) }
+        unsafe { llama_cpp_sys_2::llama_set_state_data(self.context.as_mut_ptr(), src.as_ptr()) }
     }
 
     /// Get the size of the state for a single sequence with optional flags.
@@ -484,9 +484,13 @@ impl LlamaContext<'_> {
     ///
     /// The size in bytes needed to store the sequence state.
     #[must_use]
-    pub fn state_seq_get_size_ext(&self, seq_id: i32, flags: LlamaStateSeqFlags) -> usize {
+    pub fn state_seq_get_size_ext(&mut self, seq_id: i32, flags: LlamaStateSeqFlags) -> usize {
         unsafe {
-            llama_cpp_sys_2::llama_state_seq_get_size_ext(self.context.as_ptr(), seq_id, flags.0)
+            llama_cpp_sys_2::llama_state_seq_get_size_ext(
+                self.context.as_mut_ptr(),
+                seq_id,
+                flags.0,
+            )
         }
     }
 
@@ -508,14 +512,14 @@ impl LlamaContext<'_> {
     ///
     /// The number of bytes copied.
     pub unsafe fn state_seq_get_data_ext(
-        &self,
+        &mut self,
         dest: *mut u8,
         seq_id: i32,
         flags: LlamaStateSeqFlags,
     ) -> usize {
         unsafe {
             llama_cpp_sys_2::llama_state_seq_get_data_ext(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 dest,
                 usize::MAX,
                 seq_id,
@@ -550,7 +554,7 @@ impl LlamaContext<'_> {
     ) -> bool {
         unsafe {
             llama_cpp_sys_2::llama_state_seq_set_data_ext(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 src.as_ptr(),
                 src.len(),
                 dest_seq_id,
@@ -580,17 +584,21 @@ impl LlamaContext<'_> {
     /// Returns [`StateSeqError::SizeMismatch`] if llama.cpp writes a
     /// different number of bytes than the reported state size.
     pub fn state_seq_get(
-        &self,
+        &mut self,
         seq_id: i32,
         flags: LlamaStateSeqFlags,
     ) -> Result<SeqState, crate::StateSeqError> {
         let size = unsafe {
-            llama_cpp_sys_2::llama_state_seq_get_size_ext(self.context.as_ptr(), seq_id, flags.0)
+            llama_cpp_sys_2::llama_state_seq_get_size_ext(
+                self.context.as_mut_ptr(),
+                seq_id,
+                flags.0,
+            )
         };
         let mut bytes = vec![0u8; size];
         let n = unsafe {
             llama_cpp_sys_2::llama_state_seq_get_data_ext(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 bytes.as_mut_ptr(),
                 size,
                 seq_id,
@@ -628,7 +636,7 @@ impl LlamaContext<'_> {
     ) -> Result<(), crate::StateSeqError> {
         let n = unsafe {
             llama_cpp_sys_2::llama_state_seq_set_data_ext(
-                self.context.as_ptr(),
+                self.context.as_mut_ptr(),
                 state.bytes.as_ptr(),
                 state.bytes.len(),
                 seq_id,

--- a/llama-cpp-2/src/gguf/mod.rs
+++ b/llama-cpp-2/src/gguf/mod.rs
@@ -5,7 +5,8 @@
 
 use std::ffi::{CStr, CString};
 use std::path::Path;
-use std::ptr::NonNull;
+
+use crate::ptr::Ptr;
 
 /// A safe wrapper around `gguf_context`.
 ///
@@ -13,7 +14,7 @@ use std::ptr::NonNull;
 /// never loaded into memory (`no_alloc = true`).
 #[derive(Debug)]
 pub struct GgufContext {
-    ctx: NonNull<llama_cpp_sys_2::gguf_context>,
+    ctx: Ptr<llama_cpp_sys_2::gguf_context>,
 }
 
 impl GgufContext {
@@ -29,7 +30,7 @@ impl GgufContext {
         };
         let ptr = unsafe { llama_cpp_sys_2::gguf_init_from_file(c_path.as_ptr(), params) };
         Some(Self {
-            ctx: NonNull::new(ptr)?,
+            ctx: Ptr::new(ptr)?,
         })
     }
 

--- a/llama-cpp-2/src/gguf/mod.rs
+++ b/llama-cpp-2/src/gguf/mod.rs
@@ -95,7 +95,7 @@ impl GgufContext {
 
 impl Drop for GgufContext {
     fn drop(&mut self) {
-        unsafe { llama_cpp_sys_2::gguf_free(self.ctx.as_ptr()) }
+        unsafe { llama_cpp_sys_2::gguf_free(self.ctx.as_mut_ptr()) }
     }
 }
 

--- a/llama-cpp-2/src/lib.rs
+++ b/llama-cpp-2/src/lib.rs
@@ -34,6 +34,7 @@ mod log;
 pub mod model;
 #[cfg(feature = "mtmd")]
 pub mod mtmd;
+mod ptr;
 pub mod sampling;
 #[cfg(feature = "common")]
 pub mod speculative;

--- a/llama-cpp-2/src/llguidance_sampler.rs
+++ b/llama-cpp-2/src/llguidance_sampler.rs
@@ -185,6 +185,6 @@ impl From<Matcher> for LlamaSampler {
                 Box::into_raw(ctx).cast::<c_void>(),
             )
         };
-        LlamaSampler { sampler }
+        LlamaSampler::from_raw(sampler).expect("failed allocating sampler")
     }
 }

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -779,7 +779,7 @@ impl LlamaModel {
     ///
     /// See [`LlamaLoraAdapterInitError`] for more information.
     pub fn lora_adapter_init(
-        &self,
+        &mut self,
         path: impl AsRef<Path>,
     ) -> Result<LlamaLoraAdapter, LlamaLoraAdapterInitError> {
         let path = path.as_ref();
@@ -792,8 +792,9 @@ impl LlamaModel {
             ))?;
 
         let cstr = CString::new(path)?;
-        let adapter =
-            unsafe { llama_cpp_sys_2::llama_adapter_lora_init(self.model.as_ptr(), cstr.as_ptr()) };
+        let adapter = unsafe {
+            llama_cpp_sys_2::llama_adapter_lora_init(self.model.as_mut_ptr(), cstr.as_ptr())
+        };
 
         let adapter = Ptr::new(adapter).ok_or(LlamaLoraAdapterInitError::NullResult)?;
 
@@ -816,8 +817,16 @@ impl LlamaModel {
         params: LlamaContextParams,
     ) -> Result<LlamaContext<'a>, LlamaContextLoadError> {
         let context_params = params.context_params;
+        // Constructing multiple contexts from a model in parallel is actually
+        // unsound, since `llama_new_context_with_model` mutates the model's
+        // `n_ctx_train` in some cases:
+        // <https://github.com/ggml-org/llama.cpp/blob/f45576aa86c07d60d346b469651a098a15cc4f81/src/llama-context.cpp#L3751>
+        // FIXME(madsmtm): Make this sound!
         let context = unsafe {
-            llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
+            llama_cpp_sys_2::llama_new_context_with_model(
+                self.model.as_mut_ptr_unsound(),
+                context_params,
+            )
         };
         let context = Ptr::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
@@ -841,9 +850,15 @@ impl LlamaModel {
         ctx_other: &LlamaContext<'_>,
     ) -> Result<LlamaContext<'a>, LlamaContextLoadError> {
         let mut context_params = params.context_params;
-        context_params.ctx_other = ctx_other.context.as_ptr();
+        // FIXME(madsmtm): Use `.as_ptr()` after:
+        // https://github.com/ggml-org/llama.cpp/pull/28316
+        context_params.ctx_other = unsafe { ctx_other.context.as_mut_ptr_unsound() };
+        // Unsoundness: See `LlamaMode::new_context`.
         let context = unsafe {
-            llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
+            llama_cpp_sys_2::llama_new_context_with_model(
+                self.model.as_mut_ptr_unsound(),
+                context_params,
+            )
         };
         let context = Ptr::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
@@ -901,8 +916,12 @@ impl LlamaModel {
             context_params.n_samplers = sampler_configs.len();
         }
 
+        // Unsoundness: See `LlamaMode::new_context`.
         let context = unsafe {
-            llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
+            llama_cpp_sys_2::llama_new_context_with_model(
+                self.model.as_mut_ptr_unsound(),
+                context_params,
+            )
         };
         let context = Ptr::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
@@ -1031,7 +1050,7 @@ where
 
 impl Drop for LlamaModel {
     fn drop(&mut self) {
-        unsafe { llama_cpp_sys_2::llama_free_model(self.model.as_ptr()) }
+        unsafe { llama_cpp_sys_2::llama_free_model(self.model.as_mut_ptr()) }
     }
 }
 

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -3,14 +3,13 @@ use std::ffi::{c_char, CStr, CString};
 use std::num::NonZeroU16;
 use std::os::raw::c_int;
 use std::path::Path;
-use std::ptr::{self, NonNull};
-use std::slice;
 use std::str::Utf8Error;
 
 use crate::context::params::LlamaContextParams;
 use crate::context::LlamaContext;
 use crate::llama_backend::LlamaBackend;
 use crate::model::params::LlamaModelParams;
+use crate::ptr::Ptr;
 use crate::sampling::LlamaSampler;
 use crate::token::LlamaToken;
 use crate::token_type::{LlamaTokenAttr, LlamaTokenAttrs};
@@ -27,7 +26,7 @@ pub mod params;
 #[repr(transparent)]
 #[allow(clippy::module_name_repetitions)]
 pub struct LlamaModel {
-    pub(crate) model: NonNull<llama_cpp_sys_2::llama_model>,
+    pub(crate) model: Ptr<llama_cpp_sys_2::llama_model>,
 }
 
 /// A safe wrapper around `llama_lora_adapter`.
@@ -35,7 +34,7 @@ pub struct LlamaModel {
 #[repr(transparent)]
 #[allow(clippy::module_name_repetitions)]
 pub struct LlamaLoraAdapter {
-    pub(crate) lora_adapter: NonNull<llama_cpp_sys_2::llama_adapter_lora>,
+    pub(crate) lora_adapter: Ptr<llama_cpp_sys_2::llama_adapter_lora>,
 }
 
 /// A performance-friendly wrapper around [`LlamaModel::chat_template`] which is then
@@ -768,7 +767,7 @@ impl LlamaModel {
         let llama_model =
             unsafe { llama_cpp_sys_2::llama_load_model_from_file(cstr.as_ptr(), params.params) };
 
-        let model = NonNull::new(llama_model).ok_or(LlamaModelLoadError::NullResult)?;
+        let model = Ptr::new(llama_model).ok_or(LlamaModelLoadError::NullResult)?;
 
         tracing::debug!(?path, "Loaded model");
         Ok(LlamaModel { model })
@@ -796,7 +795,7 @@ impl LlamaModel {
         let adapter =
             unsafe { llama_cpp_sys_2::llama_adapter_lora_init(self.model.as_ptr(), cstr.as_ptr()) };
 
-        let adapter = NonNull::new(adapter).ok_or(LlamaLoraAdapterInitError::NullResult)?;
+        let adapter = Ptr::new(adapter).ok_or(LlamaLoraAdapterInitError::NullResult)?;
 
         tracing::debug!(?path, "Initialized lora adapter");
         Ok(LlamaLoraAdapter {
@@ -820,7 +819,7 @@ impl LlamaModel {
         let context = unsafe {
             llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
         };
-        let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
+        let context = Ptr::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
         Ok(LlamaContext::new(self, context, params.embeddings()))
     }
@@ -846,7 +845,7 @@ impl LlamaModel {
         let context = unsafe {
             llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
         };
-        let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
+        let context = Ptr::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
         Ok(LlamaContext::new(self, context, params.embeddings()))
     }
@@ -905,7 +904,7 @@ impl LlamaModel {
         let context = unsafe {
             llama_cpp_sys_2::llama_new_context_with_model(self.model.as_ptr(), context_params)
         };
-        let context = NonNull::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
+        let context = Ptr::new(context).ok_or(LlamaContextLoadError::NullReturn)?;
 
         Ok(LlamaContext::with_samplers(
             self,

--- a/llama-cpp-2/src/model.rs
+++ b/llama-cpp-2/src/model.rs
@@ -898,15 +898,15 @@ impl LlamaModel {
         params: LlamaContextParams,
         samplers: impl IntoIterator<Item = (i32, LlamaSampler)>,
     ) -> Result<LlamaContext<'a>, LlamaContextLoadError> {
-        let samplers: Vec<_> = samplers.into_iter().collect();
+        let mut samplers: Vec<_> = samplers.into_iter().collect();
         let mut context_params = params.context_params;
 
         let mut sampler_configs: Vec<llama_cpp_sys_2::llama_sampler_seq_config> = samplers
-            .iter()
+            .iter_mut()
             .map(
                 |(seq_id, sampler)| llama_cpp_sys_2::llama_sampler_seq_config {
                     seq_id: *seq_id,
-                    sampler: sampler.sampler,
+                    sampler: sampler.sampler.as_mut_ptr(),
                 },
             )
             .collect();

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -6,11 +6,11 @@
 //! # Warning
 //! This API is experimental and subject to breaking changes.
 use std::ffi::{CStr, CString};
-use std::ptr::NonNull;
 use std::slice;
 
 use crate::context::LlamaContext;
 use crate::model::LlamaModel;
+use crate::ptr::Ptr;
 use crate::token::LlamaToken;
 
 /// Input chunk types for multimodal data
@@ -159,7 +159,7 @@ pub struct MtmdInputText {
 /// text, images, and audio through llama.cpp's multimodal interface.
 #[derive(Debug)]
 pub struct MtmdContext {
-    pub(crate) context: NonNull<llama_cpp_sys_2::mtmd_context>,
+    context: Ptr<llama_cpp_sys_2::mtmd_context>,
 }
 
 // MtmdContext is thread safe
@@ -200,7 +200,7 @@ impl MtmdContext {
             )
         };
 
-        let context = NonNull::new(context).ok_or(MtmdInitError::NullResult)?;
+        let context = Ptr::new(context).ok_or(MtmdInitError::NullResult)?;
         Ok(Self { context })
     }
 
@@ -363,7 +363,7 @@ impl Drop for MtmdContext {
 /// For audio, data is stored as PCM F32 samples.
 #[derive(Debug, Clone)]
 pub struct MtmdBitmap {
-    pub(crate) bitmap: NonNull<llama_cpp_sys_2::mtmd_bitmap>,
+    bitmap: Ptr<llama_cpp_sys_2::mtmd_bitmap>,
 }
 
 // MtmdBitmap is thread safe
@@ -407,7 +407,7 @@ impl MtmdBitmap {
 
         let bitmap = unsafe { llama_cpp_sys_2::mtmd_bitmap_init(nx, ny, data.as_ptr()) };
 
-        let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        let bitmap = Ptr::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
         Ok(Self { bitmap })
     }
 
@@ -442,7 +442,7 @@ impl MtmdBitmap {
         let bitmap =
             unsafe { llama_cpp_sys_2::mtmd_bitmap_init_from_audio(data.len(), data.as_ptr()) };
 
-        let bitmap = NonNull::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        let bitmap = Ptr::new(bitmap).ok_or(MtmdBitmapError::NullResult)?;
         Ok(Self { bitmap })
     }
 
@@ -490,7 +490,7 @@ impl MtmdBitmap {
             )
         };
 
-        let bitmap = NonNull::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        let bitmap = Ptr::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
         Ok(Self { bitmap })
     }
 
@@ -535,7 +535,7 @@ impl MtmdBitmap {
             )
         };
 
-        let bitmap = NonNull::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
+        let bitmap = Ptr::new(wrapper.bitmap).ok_or(MtmdBitmapError::NullResult)?;
         Ok(Self { bitmap })
     }
 
@@ -630,7 +630,7 @@ impl Drop for MtmdBitmap {
 /// with text chunks containing tokens and media chunks containing embeddings.
 #[derive(Debug)]
 pub struct MtmdInputChunks {
-    pub(crate) chunks: NonNull<llama_cpp_sys_2::mtmd_input_chunks>,
+    chunks: Ptr<llama_cpp_sys_2::mtmd_input_chunks>,
 }
 
 impl Default for MtmdInputChunks {
@@ -657,7 +657,7 @@ impl MtmdInputChunks {
     #[must_use]
     pub fn new() -> Self {
         let chunks = unsafe { llama_cpp_sys_2::mtmd_input_chunks_init() };
-        let chunks = NonNull::new(chunks).unwrap();
+        let chunks = Ptr::new(chunks).unwrap();
         Self { chunks }
     }
 
@@ -684,7 +684,7 @@ impl MtmdInputChunks {
             unsafe { llama_cpp_sys_2::mtmd_input_chunks_get(self.chunks.as_ptr(), index) };
 
         // Note: We don't own this chunk, it's owned by the chunks collection
-        NonNull::new(chunk_ptr.cast_mut()).map(|ptr| MtmdInputChunk {
+        Ptr::new(chunk_ptr.cast_mut()).map(|ptr| MtmdInputChunk {
             chunk: ptr,
             owned: false,
         })
@@ -779,7 +779,7 @@ impl Drop for MtmdInputChunks {
 /// data and operations are available.
 #[derive(Debug)]
 pub struct MtmdInputChunk {
-    pub(crate) chunk: NonNull<llama_cpp_sys_2::mtmd_input_chunk>,
+    chunk: Ptr<llama_cpp_sys_2::mtmd_input_chunk>,
     owned: bool,
 }
 
@@ -869,7 +869,7 @@ impl MtmdInputChunk {
     /// Returns `MtmdInputChunkError::NullResult` if copying fails.
     pub fn copy(&self) -> Result<Self, MtmdInputChunkError> {
         let chunk = unsafe { llama_cpp_sys_2::mtmd_input_chunk_copy(self.chunk.as_ptr()) };
-        let chunk = NonNull::new(chunk).ok_or(MtmdInputChunkError::NullResult)?;
+        let chunk = Ptr::new(chunk).ok_or(MtmdInputChunkError::NullResult)?;
         Ok(Self { chunk, owned: true })
     }
 }

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -361,7 +361,7 @@ impl Drop for MtmdContext {
 /// Represents bitmap data for images or audio that can be processed
 /// by the multimodal system. For images, data is stored in RGB format.
 /// For audio, data is stored as PCM F32 samples.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MtmdBitmap {
     bitmap: Ptr<llama_cpp_sys_2::mtmd_bitmap>,
 }

--- a/llama-cpp-2/src/mtmd.rs
+++ b/llama-cpp-2/src/mtmd.rs
@@ -287,7 +287,7 @@ impl MtmdContext {
         text: MtmdInputText,
         bitmaps: &[&MtmdBitmap],
     ) -> Result<MtmdInputChunks, MtmdTokenizeError> {
-        let chunks = MtmdInputChunks::new();
+        let mut chunks = MtmdInputChunks::new();
         let text_cstring = CString::new(text.text)?;
         let input_text = llama_cpp_sys_2::mtmd_input_text {
             text: text_cstring.as_ptr(),
@@ -297,15 +297,15 @@ impl MtmdContext {
         };
 
         // Create bitmap pointers
-        let bitmap_ptrs: Vec<*const llama_cpp_sys_2::mtmd_bitmap> = bitmaps
-            .iter()
-            .map(|b| b.bitmap.as_ptr().cast_const())
-            .collect();
+        let bitmap_ptrs: Vec<*const llama_cpp_sys_2::mtmd_bitmap> =
+            bitmaps.iter().map(|b| b.bitmap.as_ptr()).collect();
 
         let result = unsafe {
             llama_cpp_sys_2::mtmd_tokenize(
-                self.context.as_ptr(),
-                chunks.chunks.as_ptr(),
+                // FIXME(madsmtm): Use `.as_ptr()` after:
+                // https://github.com/ggml-org/llama.cpp/pull/28307
+                self.context.as_mut_ptr_unsound(),
+                chunks.chunks.as_mut_ptr(),
                 &raw const input_text,
                 bitmap_ptrs.as_ptr().cast_mut(),
                 bitmaps.len(),
@@ -337,9 +337,9 @@ impl MtmdContext {
     /// # Errors
     ///
     /// Returns `MtmdEncodeError::EncodeFailure` if encoding fails.
-    pub fn encode_chunk(&self, chunk: &MtmdInputChunk) -> Result<(), MtmdEncodeError> {
+    pub fn encode_chunk(&mut self, chunk: &MtmdInputChunk) -> Result<(), MtmdEncodeError> {
         let result = unsafe {
-            llama_cpp_sys_2::mtmd_encode_chunk(self.context.as_ptr(), chunk.chunk.as_ptr())
+            llama_cpp_sys_2::mtmd_encode_chunk(self.context.as_mut_ptr(), chunk.chunk.as_ptr())
         };
 
         if result == 0 {
@@ -352,7 +352,7 @@ impl MtmdContext {
 
 impl Drop for MtmdContext {
     fn drop(&mut self) {
-        unsafe { llama_cpp_sys_2::mtmd_free(self.context.as_ptr()) }
+        unsafe { llama_cpp_sys_2::mtmd_free(self.context.as_mut_ptr()) }
     }
 }
 
@@ -484,7 +484,9 @@ impl MtmdBitmap {
         // with it on, so it is always null here and only the bitmap matters.
         let wrapper = unsafe {
             llama_cpp_sys_2::mtmd_helper_bitmap_init_from_file(
-                ctx.context.as_ptr(),
+                // FIXME(madsmtm): Use `.as_ptr()` after:
+                // https://github.com/ggml-org/llama.cpp/pull/28307
+                ctx.context.as_mut_ptr_unsound(),
                 path_cstr.as_ptr(),
                 placeholder,
             )
@@ -528,7 +530,9 @@ impl MtmdBitmap {
         // `video_ctx` is always null since MTMD_VIDEO is not enabled in this build.
         let wrapper = unsafe {
             llama_cpp_sys_2::mtmd_helper_bitmap_init_from_buf(
-                ctx.context.as_ptr(),
+                // FIXME(madsmtm): Use `.as_ptr()` after:
+                // https://github.com/ggml-org/llama.cpp/pull/28307
+                ctx.context.as_mut_ptr_unsound(),
                 data.as_ptr(),
                 data.len(),
                 placeholder,
@@ -602,16 +606,16 @@ impl MtmdBitmap {
     ///
     /// ```no_run
     /// # use llama_cpp_2::mtmd::MtmdBitmap;
-    /// # fn example(bitmap: &MtmdBitmap) -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example(bitmap: &mut MtmdBitmap) -> Result<(), Box<dyn std::error::Error>> {
     /// bitmap.set_id("image_001")?;
     /// assert_eq!(bitmap.id(), Some("image_001".to_string()));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set_id(&self, id: &str) -> Result<(), std::ffi::NulError> {
+    pub fn set_id(&mut self, id: &str) -> Result<(), std::ffi::NulError> {
         let id_cstr = CString::new(id)?;
         unsafe {
-            llama_cpp_sys_2::mtmd_bitmap_set_id(self.bitmap.as_ptr(), id_cstr.as_ptr());
+            llama_cpp_sys_2::mtmd_bitmap_set_id(self.bitmap.as_mut_ptr(), id_cstr.as_ptr());
         }
         Ok(())
     }
@@ -619,7 +623,7 @@ impl MtmdBitmap {
 
 impl Drop for MtmdBitmap {
     fn drop(&mut self) {
-        unsafe { llama_cpp_sys_2::mtmd_bitmap_free(self.bitmap.as_ptr()) }
+        unsafe { llama_cpp_sys_2::mtmd_bitmap_free(self.bitmap.as_mut_ptr()) }
     }
 }
 
@@ -736,8 +740,8 @@ impl MtmdInputChunks {
     /// This function is NOT thread-safe.
     pub fn eval_chunks(
         &self,
-        mtmd_ctx: &MtmdContext,
-        llama_ctx: &LlamaContext,
+        mtmd_ctx: &mut MtmdContext,
+        llama_ctx: &mut LlamaContext,
         n_past: llama_cpp_sys_2::llama_pos,
         seq_id: llama_cpp_sys_2::llama_seq_id,
         n_batch: i32,
@@ -747,8 +751,8 @@ impl MtmdInputChunks {
 
         let result = unsafe {
             llama_cpp_sys_2::mtmd_helper_eval_chunks(
-                mtmd_ctx.context.as_ptr(),
-                llama_ctx.context.as_ptr(),
+                mtmd_ctx.context.as_mut_ptr(),
+                llama_ctx.context.as_mut_ptr(),
                 self.chunks.as_ptr(),
                 n_past,
                 seq_id,
@@ -768,7 +772,7 @@ impl MtmdInputChunks {
 
 impl Drop for MtmdInputChunks {
     fn drop(&mut self) {
-        unsafe { llama_cpp_sys_2::mtmd_input_chunks_free(self.chunks.as_ptr()) }
+        unsafe { llama_cpp_sys_2::mtmd_input_chunks_free(self.chunks.as_mut_ptr()) }
     }
 }
 
@@ -877,7 +881,7 @@ impl MtmdInputChunk {
 impl Drop for MtmdInputChunk {
     fn drop(&mut self) {
         if self.owned {
-            unsafe { llama_cpp_sys_2::mtmd_input_chunk_free(self.chunk.as_ptr()) }
+            unsafe { llama_cpp_sys_2::mtmd_input_chunk_free(self.chunk.as_mut_ptr()) }
         }
     }
 }

--- a/llama-cpp-2/src/ptr.rs
+++ b/llama-cpp-2/src/ptr.rs
@@ -2,7 +2,6 @@ use core::fmt;
 use std::ptr::NonNull;
 
 #[repr(transparent)]
-#[derive(Clone)]
 pub(crate) struct Ptr<T: ?Sized>(NonNull<T>);
 
 impl<T: ?Sized> Ptr<T> {

--- a/llama-cpp-2/src/ptr.rs
+++ b/llama-cpp-2/src/ptr.rs
@@ -1,0 +1,26 @@
+use core::fmt;
+use std::ptr::NonNull;
+
+#[repr(transparent)]
+#[derive(Clone)]
+pub(crate) struct Ptr<T: ?Sized>(NonNull<T>);
+
+impl<T: ?Sized> Ptr<T> {
+    #[inline]
+    pub(crate) fn new(ptr: *mut T) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    #[inline]
+    pub(crate) const fn as_ptr(&self) -> *mut T {
+        self.0.as_ptr()
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for Ptr<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Forward to inner Debug
+        fmt::Debug::fmt(&self.0, f)
+    }
+}

--- a/llama-cpp-2/src/ptr.rs
+++ b/llama-cpp-2/src/ptr.rs
@@ -11,7 +11,20 @@ impl<T: ?Sized> Ptr<T> {
     }
 
     #[inline]
-    pub(crate) const fn as_ptr(&self) -> *mut T {
+    pub(crate) const fn as_ptr(&self) -> *const T {
+        self.0.as_ptr().cast_const()
+    }
+
+    #[inline]
+    pub(crate) const fn as_mut_ptr(&mut self) -> *mut T {
+        self.0.as_ptr()
+    }
+
+    /// Temporary helper to allow getting a mutable pointer from an immutable
+    /// reference.
+    /// FIXME(madsmtm): Get rid of this!
+    #[inline]
+    pub(crate) const unsafe fn as_mut_ptr_unsound(&self) -> *mut T {
         self.0.as_ptr()
     }
 }

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -27,9 +27,9 @@ impl Debug for LlamaSampler {
 impl LlamaSampler {
     /// Sample and accept a token from the idx-th output of the last evaluation
     #[must_use]
-    pub fn sample(&mut self, ctx: &LlamaContext, idx: i32) -> LlamaToken {
+    pub fn sample(&mut self, ctx: &mut LlamaContext, idx: i32) -> LlamaToken {
         let token = unsafe {
-            llama_cpp_sys_2::llama_sampler_sample(self.sampler, ctx.context.as_ptr(), idx)
+            llama_cpp_sys_2::llama_sampler_sample(self.sampler, ctx.context.as_mut_ptr(), idx)
         };
 
         LlamaToken(token)

--- a/llama-cpp-2/src/sampling.rs
+++ b/llama-cpp-2/src/sampling.rs
@@ -3,9 +3,11 @@
 use std::borrow::Borrow;
 use std::ffi::{c_char, CString};
 use std::fmt::{Debug, Formatter};
+use std::mem::ManuallyDrop;
 
 use crate::context::LlamaContext;
 use crate::model::LlamaModel;
+use crate::ptr::Ptr;
 #[cfg(feature = "common")]
 use crate::status_is_ok;
 use crate::token::data_array::LlamaTokenDataArray;
@@ -15,7 +17,7 @@ use crate::{GrammarError, SamplerAcceptError};
 
 /// A safe wrapper around `llama_sampler`.
 pub struct LlamaSampler {
-    pub(crate) sampler: *mut llama_cpp_sys_2::llama_sampler,
+    pub(crate) sampler: Ptr<llama_cpp_sys_2::llama_sampler>,
 }
 
 impl Debug for LlamaSampler {
@@ -25,18 +27,28 @@ impl Debug for LlamaSampler {
 }
 
 impl LlamaSampler {
+    #[inline]
+    pub(crate) fn from_raw(ptr: *mut llama_cpp_sys_2::llama_sampler) -> Option<Self> {
+        let sampler = Ptr::new(ptr)?;
+        Some(Self { sampler })
+    }
+
     /// Sample and accept a token from the idx-th output of the last evaluation
     #[must_use]
     pub fn sample(&mut self, ctx: &mut LlamaContext, idx: i32) -> LlamaToken {
         let token = unsafe {
-            llama_cpp_sys_2::llama_sampler_sample(self.sampler, ctx.context.as_mut_ptr(), idx)
+            llama_cpp_sys_2::llama_sampler_sample(
+                self.sampler.as_mut_ptr(),
+                ctx.context.as_mut_ptr(),
+                idx,
+            )
         };
 
         LlamaToken(token)
     }
 
     /// Applies this sampler to a [`LlamaTokenDataArray`].
-    pub fn apply(&self, data_array: &mut LlamaTokenDataArray) {
+    pub fn apply(&mut self, data_array: &mut LlamaTokenDataArray) {
         data_array.apply_sampler(self);
     }
 
@@ -49,7 +61,7 @@ impl LlamaSampler {
         }
         #[cfg(not(feature = "common"))]
         unsafe {
-            llama_cpp_sys_2::llama_sampler_accept(self.sampler, token.0);
+            llama_cpp_sys_2::llama_sampler_accept(self.sampler.as_mut_ptr(), token.0);
         }
     }
 
@@ -76,7 +88,7 @@ impl LlamaSampler {
     #[cfg(feature = "common")]
     pub fn try_accept(&mut self, token: LlamaToken) -> Result<(), SamplerAcceptError> {
         let sampler_result =
-            unsafe { llama_cpp_sys_2::llama_rs_sampler_accept(self.sampler, token.0) };
+            unsafe { llama_cpp_sys_2::llama_rs_sampler_accept(self.sampler.as_mut_ptr(), token.0) };
         if status_is_ok(sampler_result) {
             Ok(())
         } else {
@@ -89,7 +101,7 @@ impl LlamaSampler {
     /// This can be useful when you want to start fresh with a sampler without creating a new instance.
     pub fn reset(&mut self) {
         unsafe {
-            llama_cpp_sys_2::llama_sampler_reset(self.sampler);
+            llama_cpp_sys_2::llama_sampler_reset(self.sampler.as_mut_ptr());
         }
     }
 
@@ -101,7 +113,7 @@ impl LlamaSampler {
     /// - For all other samplers: returns 0xFFFFFFFF
     #[must_use]
     pub fn get_seed(&self) -> u32 {
-        unsafe { llama_cpp_sys_2::llama_sampler_get_seed(self.sampler) }
+        unsafe { llama_cpp_sys_2::llama_sampler_get_seed(self.sampler.as_ptr()) }
     }
 
     /// Combines a list of samplers into a single sampler that applies each component sampler one
@@ -112,21 +124,25 @@ impl LlamaSampler {
     /// [`LlamaSampler::mirostat_v2`].
     #[must_use]
     pub fn chain(samplers: impl IntoIterator<Item = Self>, no_perf: bool) -> Self {
-        unsafe {
-            let chain = llama_cpp_sys_2::llama_sampler_chain_init(
-                llama_cpp_sys_2::llama_sampler_chain_params { no_perf },
-            );
+        let params = llama_cpp_sys_2::llama_sampler_chain_params { no_perf };
 
-            for sampler in samplers {
-                llama_cpp_sys_2::llama_sampler_chain_add(chain, sampler.sampler);
+        let chain = unsafe { llama_cpp_sys_2::llama_sampler_chain_init(params) };
+        let mut chain = Ptr::new(chain).expect("failed allocating sampler chain");
 
-                // Do not call `llama_sampler_free` on the sampler, as the internal sampler is now
-                // owned by the chain
-                std::mem::forget(sampler);
-            }
+        for sampler in samplers {
+            // Do not call `llama_sampler_free` on the sampler, we want to
+            // transfer ownership to the chain.
+            let mut sampler = ManuallyDrop::new(sampler);
 
-            Self { sampler: chain }
+            unsafe {
+                llama_cpp_sys_2::llama_sampler_chain_add(
+                    chain.as_mut_ptr(),
+                    sampler.sampler.as_mut_ptr(),
+                )
+            };
         }
+
+        Self { sampler: chain }
     }
 
     /// Same as [`Self::chain`] with `no_perf = false`.
@@ -193,7 +209,7 @@ impl LlamaSampler {
     #[must_use]
     pub fn temp(t: f32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_temp(t) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Dynamic temperature implementation (a.k.a. entropy) described in the paper
@@ -201,7 +217,7 @@ impl LlamaSampler {
     #[must_use]
     pub fn temp_ext(t: f32, delta: f32, exponent: f32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_temp_ext(t, delta, exponent) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Top-K sampling described in academic paper "The Curious Case of Neural Text Degeneration"
@@ -232,7 +248,7 @@ impl LlamaSampler {
     #[must_use]
     pub fn top_k(k: i32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_top_k(k) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Top-nσ sampling as described in academic paper "Top-nσ: Not All Logits Are You Need"
@@ -263,14 +279,14 @@ impl LlamaSampler {
     #[must_use]
     pub fn top_n_sigma(n: f32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_top_n_sigma(n) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Locally Typical Sampling implementation described in the paper <https://arxiv.org/abs/2202.00666>.
     #[must_use]
     pub fn typical(p: f32, min_keep: usize) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_typical(p, min_keep) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Nucleus sampling described in academic paper "The Curious Case of Neural Text Degeneration"
@@ -278,21 +294,21 @@ impl LlamaSampler {
     #[must_use]
     pub fn top_p(p: f32, min_keep: usize) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_top_p(p, min_keep) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Minimum P sampling as described in <https://github.com/ggerganov/llama.cpp/pull/3841>
     #[must_use]
     pub fn min_p(p: f32, min_keep: usize) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_min_p(p, min_keep) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// XTC sampler as described in <https://github.com/oobabooga/text-generation-webui/pull/6335>
     #[must_use]
     pub fn xtc(p: f32, t: f32, min_keep: usize, seed: u32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_xtc(p, t, min_keep, seed) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Grammar sampler
@@ -325,7 +341,7 @@ impl LlamaSampler {
         if sampler.is_null() {
             Err(GrammarError::NullGrammar)
         } else {
-            Ok(Self { sampler })
+            Ok(Self::from_raw(sampler).unwrap())
         }
     }
 
@@ -363,7 +379,7 @@ impl LlamaSampler {
         if sampler.is_null() {
             Err(GrammarError::NullGrammar)
         } else {
-            Ok(Self { sampler })
+            Ok(Self::from_raw(sampler).unwrap())
         }
     }
 
@@ -421,7 +437,7 @@ impl LlamaSampler {
         if sampler.is_null() {
             Err(GrammarError::NullGrammar)
         } else {
-            Ok(Self { sampler })
+            Ok(Self::from_raw(sampler).unwrap())
         }
     }
 
@@ -518,7 +534,7 @@ impl LlamaSampler {
                 seq_breaker_pointers.len(),
             )
         };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Penalizes tokens for being present in the context.
@@ -548,7 +564,7 @@ impl LlamaSampler {
                 penalty_present,
             )
         };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Mirostat 1.0 algorithm described in the paper <https://arxiv.org/abs/2007.14966>. Uses tokens instead of words.
@@ -570,7 +586,7 @@ impl LlamaSampler {
     pub fn mirostat(n_vocab: i32, seed: u32, tau: f32, eta: f32, m: i32) -> Self {
         let sampler =
             unsafe { llama_cpp_sys_2::llama_sampler_init_mirostat(n_vocab, seed, tau, eta, m) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Mirostat 2.0 algorithm described in the paper <https://arxiv.org/abs/2007.14966>. Uses tokens instead of words.
@@ -586,14 +602,14 @@ impl LlamaSampler {
     #[must_use]
     pub fn mirostat_v2(seed: u32, tau: f32, eta: f32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_mirostat_v2(seed, tau, eta) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Selects a token at random based on each token's probabilities
     #[must_use]
     pub fn dist(seed: u32) -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_dist(seed) };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Selects the most likely token
@@ -620,7 +636,7 @@ impl LlamaSampler {
     #[must_use]
     pub fn greedy() -> Self {
         let sampler = unsafe { llama_cpp_sys_2::llama_sampler_init_greedy() };
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 
     /// Creates a sampler that applies bias values to specific tokens during sampling.
@@ -650,14 +666,12 @@ impl LlamaSampler {
             llama_cpp_sys_2::llama_sampler_init_logit_bias(n_vocab, biases.len() as i32, data)
         };
 
-        Self { sampler }
+        Self::from_raw(sampler).expect("failed allocating sampler")
     }
 }
 
 impl Drop for LlamaSampler {
     fn drop(&mut self) {
-        unsafe {
-            llama_cpp_sys_2::llama_sampler_free(self.sampler);
-        }
+        unsafe { llama_cpp_sys_2::llama_sampler_free(self.sampler.as_mut_ptr()) };
     }
 }

--- a/llama-cpp-2/src/speculative.rs
+++ b/llama-cpp-2/src/speculative.rs
@@ -1,9 +1,8 @@
 //! Experimental wrappers for llama.cpp speculative decoding helpers.
 
-use std::ptr::NonNull;
-
 use crate::context::LlamaContext;
 use crate::llama_batch::LlamaBatch;
+use crate::ptr::Ptr;
 use crate::status_is_ok;
 use crate::token::LlamaToken;
 
@@ -51,7 +50,7 @@ pub enum MtpSpeculativeError {
 /// Batches passed to [`Self::process`] must therefore contain only sequence 0.
 #[derive(Debug)]
 pub struct MtpSpeculative<'model> {
-    raw: NonNull<llama_cpp_sys_2::llama_rs_mtp_speculative>,
+    raw: Ptr<llama_cpp_sys_2::llama_rs_mtp_speculative>,
     target_context: LlamaContext<'model>,
     draft_context: LlamaContext<'model>,
     n_max: usize,
@@ -85,7 +84,7 @@ impl<'model> MtpSpeculative<'model> {
                 params.p_min,
             )
         };
-        let raw = NonNull::new(raw).ok_or(MtpSpeculativeError::InitFailed)?;
+        let raw = Ptr::new(raw).ok_or(MtpSpeculativeError::InitFailed)?;
 
         Ok(Self {
             raw,

--- a/llama-cpp-2/src/speculative.rs
+++ b/llama-cpp-2/src/speculative.rs
@@ -65,8 +65,8 @@ impl<'model> MtpSpeculative<'model> {
     /// Returns an error if parameters are invalid or llama.cpp cannot
     /// initialize the speculative implementation for the loaded model.
     pub fn new(
-        target_context: LlamaContext<'model>,
-        draft_context: LlamaContext<'model>,
+        mut target_context: LlamaContext<'model>,
+        mut draft_context: LlamaContext<'model>,
         params: MtpSpeculativeParams,
     ) -> Result<Self, MtpSpeculativeError> {
         if params.n_max <= 0 || params.n_min < 0 || params.n_min > params.n_max {
@@ -77,8 +77,8 @@ impl<'model> MtpSpeculative<'model> {
 
         let raw = unsafe {
             llama_cpp_sys_2::llama_rs_mtp_speculative_init(
-                target_context.context.as_ptr(),
-                draft_context.context.as_ptr(),
+                target_context.context.as_mut_ptr(),
+                draft_context.context.as_mut_ptr(),
                 params.n_max,
                 params.n_min,
                 params.p_min,
@@ -119,7 +119,7 @@ impl<'model> MtpSpeculative<'model> {
         let prompt = tokens_to_raw(prompt_tokens);
         let status = unsafe {
             llama_cpp_sys_2::llama_rs_mtp_speculative_begin(
-                self.raw.as_ptr(),
+                self.raw.as_mut_ptr(),
                 prompt.as_ptr(),
                 prompt.len(),
             )
@@ -137,7 +137,7 @@ impl<'model> MtpSpeculative<'model> {
     pub fn process(&mut self, batch: &LlamaBatch<'_>) -> Result<(), MtpSpeculativeError> {
         let status = unsafe {
             llama_cpp_sys_2::llama_rs_mtp_speculative_process(
-                self.raw.as_ptr(),
+                self.raw.as_mut_ptr(),
                 std::ptr::from_ref(&batch.llama_batch),
             )
         };
@@ -165,7 +165,7 @@ impl<'model> MtpSpeculative<'model> {
         let mut out_len = 0_usize;
         let status = unsafe {
             llama_cpp_sys_2::llama_rs_mtp_speculative_draft(
-                self.raw.as_ptr(),
+                self.raw.as_mut_ptr(),
                 n_past,
                 id_last.0,
                 prompt.as_ptr(),
@@ -190,7 +190,7 @@ impl<'model> MtpSpeculative<'model> {
     /// Returns an error if llama.cpp rejects the call.
     pub fn accept(&mut self, n_accepted: u16) -> Result<(), MtpSpeculativeError> {
         let status = unsafe {
-            llama_cpp_sys_2::llama_rs_mtp_speculative_accept(self.raw.as_ptr(), n_accepted)
+            llama_cpp_sys_2::llama_rs_mtp_speculative_accept(self.raw.as_mut_ptr(), n_accepted)
         };
         status_to_result(status)
     }
@@ -198,9 +198,7 @@ impl<'model> MtpSpeculative<'model> {
 
 impl Drop for MtpSpeculative<'_> {
     fn drop(&mut self) {
-        unsafe {
-            llama_cpp_sys_2::llama_rs_mtp_speculative_free(self.raw.as_ptr());
-        }
+        unsafe { llama_cpp_sys_2::llama_rs_mtp_speculative_free(self.raw.as_mut_ptr()) }
     }
 }
 

--- a/llama-cpp-2/src/token/data_array.rs
+++ b/llama-cpp-2/src/token/data_array.rs
@@ -121,10 +121,13 @@ impl LlamaTokenDataArray {
     }
 
     /// Modifies the data array by applying a sampler to it
-    pub fn apply_sampler(&mut self, sampler: &LlamaSampler) {
+    pub fn apply_sampler(&mut self, sampler: &mut LlamaSampler) {
         unsafe {
             self.modify_as_c_llama_token_data_array(|c_llama_token_data_array| {
-                llama_cpp_sys_2::llama_sampler_apply(sampler.sampler, c_llama_token_data_array);
+                llama_cpp_sys_2::llama_sampler_apply(
+                    sampler.sampler.as_mut_ptr(),
+                    c_llama_token_data_array,
+                );
             });
         }
     }
@@ -141,7 +144,7 @@ impl LlamaTokenDataArray {
     /// # Panics
     /// If the internal llama.cpp sampler fails to select a token.
     pub fn sample_token(&mut self, seed: u32) -> LlamaToken {
-        self.apply_sampler(&LlamaSampler::dist(seed));
+        self.apply_sampler(&mut LlamaSampler::dist(seed));
         self.selected_token()
             .expect("Dist sampler failed to select a token!")
     }
@@ -151,7 +154,7 @@ impl LlamaTokenDataArray {
     /// # Panics
     /// If the internal llama.cpp sampler fails to select a token.
     pub fn sample_token_greedy(&mut self) -> LlamaToken {
-        self.apply_sampler(&LlamaSampler::greedy());
+        self.apply_sampler(&mut LlamaSampler::greedy());
         self.selected_token()
             .expect("Greedy sampler failed to select a token!")
     }


### PR DESCRIPTION
The `llama.cpp` API is actually fairly Rusty, and communicates pretty well which function parameters are mutated (either the parameter is `const`, and it's not mutated, or it's not `const`, and it's potentially mutated).

We can take advantage of this information by introducing a helper `Ptr` with methods `as_ptr(&self) -> *const T` and `as_mut_ptr(&mut self) -> *mut T` to access the underlying pointer, which then ensures that when the API requires a `*mut` pointer, it came from a `&mut`.

This also removes an incorrect `Clone` impl on `MtmdBitmap` that would lead to a double-free and/or use-after-free.