### PR TITLE
feat(params): `with_tensor_split` to set each device's share of the model

### DIFF
--- a/llama-cpp-2/src/model/params.rs
+++ b/llama-cpp-2/src/model/params.rs
@@ -559,6 +559,44 @@ impl LlamaModelParams {
         self
     }
 
+    /// Sets each device's share of the model, parallel to
+    /// [`with_devices`](Self::with_devices).
+    ///
+    /// Shares are relative, so they need not sum to one. An empty slice clears the split and
+    /// restores llama.cpp's default, which distributes in proportion to free memory. The
+    /// slice is padded with zeroes to `llama_max_devices()`, as the C API requires.
+    ///
+    /// The pointer handed to llama.cpp addresses the `Vec`'s heap buffer, not this struct, so
+    /// it survives the moves that builder chaining performs.
+    ///
+    /// # Errors
+    /// Returns `LlamaCppError::MaxDevicesExceeded` if `split` is longer than
+    /// `llama_max_devices()`.
+    pub fn with_tensor_split(mut self, split: &[f32]) -> Result<Self, LlamaCppError> {
+        if split.is_empty() {
+            self.tensor_split.clear();
+            self.params.tensor_split = null::<f32>();
+            return Ok(self);
+        }
+        let max_devices = crate::max_devices();
+        if split.len() > max_devices {
+            return Err(LlamaCppError::MaxDevicesExceeded(max_devices));
+        }
+        self.tensor_split.clear();
+        self.tensor_split.extend_from_slice(split);
+        self.tensor_split.resize(max_devices, 0.0);
+        self.params.tensor_split = self.tensor_split.as_ptr();
+        Ok(self)
+    }
+
+    /// Each device's share of the model, as last set by
+    /// [`with_tensor_split`](Self::with_tensor_split). Empty when the split is llama.cpp's
+    /// free-memory default.
+    #[must_use]
+    pub fn tensor_split(&self) -> &[f32] {
+        &self.tensor_split
+    }
+
     /// sets `devices`
     ///
     /// The devices are specified as indices that correspond to the ggml backend device indices.
@@ -699,6 +737,32 @@ mod tests {
             params.tensor_buft_override_patterns(),
             vec!["\\.ffn_(up|down|gate)_(ch|)exps".to_owned()],
         );
+    }
+
+    #[test]
+    fn tensor_split_round_trips_and_pads() {
+        use super::LlamaModelParams;
+        let max = crate::max_devices();
+        let params = LlamaModelParams::default()
+            .with_tensor_split(&[0.25, 0.75])
+            .expect("two devices is under any max");
+        assert_eq!(params.tensor_split().len(), max);
+        assert_eq!(&params.tensor_split()[..2], &[0.25, 0.75]);
+        assert!(params.tensor_split()[2..].iter().all(|share| *share == 0.0));
+
+        // The pointer must survive the moves builder chaining performs.
+        let params = params.with_n_gpu_layers(99);
+        assert_eq!(&params.tensor_split()[..2], &[0.25, 0.75]);
+
+        let cleared = params.with_tensor_split(&[]).expect("empty clears");
+        assert!(cleared.tensor_split().is_empty());
+    }
+
+    #[test]
+    fn tensor_split_rejects_more_devices_than_llama_supports() {
+        use super::LlamaModelParams;
+        let too_many = vec![1.0_f32; crate::max_devices() + 1];
+        assert!(LlamaModelParams::default().with_tensor_split(&too_many).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `LlamaModelParams::with_tensor_split(&[f32])`, the safe setter for `llama_model_params::tensor_split`: the proportion of the model each device in `with_devices` receives. The slice is copied into the params struct's fixed-size array (`LLAMA_MAX_DEVICES`), with the remaining entries zeroed, so the caller never touches raw pointers or the array length. Also exposes the current value via `tensor_split()`.

## Why

`with_devices` selects which backends load a model, but without `tensor_split` llama.cpp decides the proportions by free memory alone. A caller placing a model deliberately (a small GPU beside a large one, or a device that should hold a fixed share) has no way to say so from the Rust side today, although `llama-cli --tensor-split` exposes it. This is the last piece of `llama_model_params` around device placement not reachable from the safe API.

Scope is deliberately just the params setter, in the spirit of the "safe API to the core llama.cpp features" scoping in #809.

## Test

`cargo check -p llama-cpp-2` on this branch; used in a downstream crate that splits a 26B model across two machines' GPUs by explicit proportions.