### PR TITLE
Don't set GGML_CPU_ARM_ARCH when dynamic-backends is enabled

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -876,7 +876,22 @@ fn main() {
         // If the target-cpu is not specified as native, we take off the native ARM64 support.
         // It is useful in docker environments where the native feature is not enabled.
         config.define("GGML_NATIVE", "OFF");
-        config.define("GGML_CPU_ARM_ARCH", "armv8-a");
+
+        // ...but do NOT pin a single architecture when `dynamic-backends` is on:
+        // that feature sets GGML_CPU_ALL_VARIANTS, and ggml rejects the pair
+        //     "Cannot use both GGML_CPU_ARM_ARCH and GGML_CPU_ALL_VARIANTS"
+        // (ggml/src/CMakeLists.txt), so every non-native aarch64 Linux build with
+        // the feature enabled fails at configure time. `target-cpu=native` is the
+        // only value that skips this block, and it is unusable for a distributed
+        // artifact because it compiles for the build machine's own CPU.
+        //
+        // Leaving the variable unset is what the feature wants anyway:
+        // GGML_CPU_ALL_VARIANTS builds armv8.0 through armv9.2 and dispatches on
+        // the host's capabilities at load time, which is strictly better than the
+        // fixed armv8-a baseline this line would otherwise impose.
+        if !cfg!(feature = "dynamic-backends") {
+            config.define("GGML_CPU_ARM_ARCH", "armv8-a");
+        }
     }
 
     if cfg!(feature = "vulkan") {


### PR DESCRIPTION
On aarch64 Linux, `build.rs` pins a single CPU architecture:

```rust
if matches!(target_os, TargetOs::Linux)
    && target_triple.contains("aarch64")
    && target_cpu != Some("native".into())
{
    config.define("GGML_NATIVE", "OFF");
    config.define("GGML_CPU_ARM_ARCH", "armv8-a");   // <-- here
}
```

while the `dynamic-backends` feature sets `GGML_CPU_ALL_VARIANTS`:

```rust
if cfg!(feature = "dynamic-backends") {
    config.define("GGML_BACKEND_DL", "ON");
    config.define("GGML_CPU_ALL_VARIANTS", "ON");    // <-- and here
    ...
}
```

ggml treats those as mutually exclusive (`ggml/src/CMakeLists.txt`):

```cmake
if (GGML_CPU_ALL_VARIANTS)
    if (NOT GGML_BACKEND_DL)
        message(FATAL_ERROR "GGML_CPU_ALL_VARIANTS requires GGML_BACKEND_DL")
    elseif (GGML_CPU_ARM_ARCH)
        message(FATAL_ERROR "Cannot use both GGML_CPU_ARM_ARCH and GGML_CPU_ALL_VARIANTS")
    endif()
```

so **every non-native aarch64 Linux build with `dynamic-backends` fails at configure time**:

```
CMake Error at ggml/src/CMakeLists.txt:375 (message):
  Cannot use both GGML_CPU_ARM_ARCH and GGML_CPU_ALL_VARIANTS
thread 'main' panicked at cmake-0.1.58/src/lib.rs:1132:5:
command did not execute successfully, got: exit status: 1
```

### Reproduce

```toml
llama-cpp-2 = { version = "0.1.156", default-features = false, features = ["vulkan", "dynamic-backends"] }
```

```
cargo build --target aarch64-unknown-linux-gnu
```

`-C target-cpu=native` is currently the only way around it, since it is the one value the guard checks for. That is not usable for a redistributable artifact: it compiles for the build machine's own CPU, which on our arm64 builder resolves to `apple-m4`.

### The change

Skip the pin when the feature is enabled. This is also what the feature is for — `GGML_CPU_ALL_VARIANTS` builds the full ladder and dispatches on the host at load time, which is strictly better than a fixed `armv8-a` baseline. Behaviour without `dynamic-backends` is unchanged.

### Verified

Built `aarch64-unknown-linux-gnu` in a container with `["vulkan", "dynamic-backends"]`. Configure succeeds and the ladder is produced:

```
libggml-cpu-armv8.0_1.so   libggml-cpu-armv8.6_1.so
libggml-cpu-armv8.2_1.so   libggml-cpu-armv8.6_2.so
libggml-cpu-armv8.2_2.so   libggml-cpu-armv9.2_1.so
libggml-cpu-armv8.2_3.so   libggml-cpu-armv9.2_2.so
libggml-vulkan.so          libggml-base.so
```

(The `armv9.2` variants need GCC 12+; this was built with GCC 15.2 on Ubuntu 26.04.)