### PR TITLE
fix(build): emit libc++ only once on Apple targets

### DIFF
--- a/llama-cpp-sys-2/build.rs
+++ b/llama-cpp-sys-2/build.rs
@@ -630,9 +630,15 @@ fn main() {
             common_wrapper_build.flag("/std:c++17");
         }
 
-        // When static-stdcxx is enabled on Android, suppress the cc crate's automatic
-        // C++ stdlib linking (which defaults to c++_shared) so we can link c++_static instead.
-        if matches!(target_os, TargetOs::Android) && cfg!(feature = "static-stdcxx") {
+        // Suppress cc's automatic C++ stdlib link when this build script already
+        // emits an explicit `cargo:rustc-link-lib` for it. Otherwise Apple
+        // gets duplicate `-lc++` (cc defaults to `c++` there, and we println
+        // the same flag below), which has segfaulted clang under memory pressure.
+        // Android static-stdcxx still needs this so we can link `c++_static`
+        // instead of cc's default `c++_shared`.
+        if matches!(target_os, TargetOs::Apple(_))
+            || (matches!(target_os, TargetOs::Android) && cfg!(feature = "static-stdcxx"))
+        {
             common_wrapper_build.cpp_link_stdlib(None);
         }
 
@@ -1112,9 +1118,12 @@ fn main() {
             mtmd_build.flag("/std:c++17");
         }
 
-        // When static-stdcxx is enabled on Android, suppress the cc crate's automatic
-        // C++ stdlib linking (which defaults to c++_shared) so we can link c++_static instead.
-        if matches!(target_os, TargetOs::Android) && cfg!(feature = "static-stdcxx") {
+        // Same rationale as the common wrapper: Apple emits an explicit
+        // `cargo:rustc-link-lib=c++` below, and Android static-stdcxx emits
+        // `c++_static` instead of cc's default `c++_shared`.
+        if matches!(target_os, TargetOs::Apple(_))
+            || (matches!(target_os, TargetOs::Android) && cfg!(feature = "static-stdcxx"))
+        {
             mtmd_build.cpp_link_stdlib(None);
         }
 

--- a/llama-cpp-sys-2/src/lib.rs
+++ b/llama-cpp-sys-2/src/lib.rs
@@ -6,3 +6,35 @@
 #![allow(unpredictable_function_pointer_comparisons)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cxx_stdlib_link_directive_is_not_duplicated() {
+        let out_dir = env!("OUT_DIR");
+        let output_path = std::path::Path::new(out_dir)
+            .parent()
+            .expect("OUT_DIR should have a parent build directory")
+            .join("output");
+        let output = std::fs::read_to_string(&output_path).unwrap_or_else(|err| {
+            panic!(
+                "failed to read build script output {}: {err}",
+                output_path.display()
+            );
+        });
+        let cxx_link_count = output
+            .lines()
+            .filter(|line| *line == "cargo:rustc-link-lib=c++")
+            .count();
+        assert!(
+            cxx_link_count <= 1,
+            "build.rs emitted cargo:rustc-link-lib=c++ {cxx_link_count} times; \
+             the cc crate auto-link plus the explicit Apple println must not both fire"
+        );
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            cxx_link_count, 1,
+            "macOS must still link libc++ exactly once via the explicit Apple directive"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Both C++ `cc::Build` sites (the `common` wrapper and `mtmd`) now call `cpp_link_stdlib(None)` on Apple, the same way this file already suppresses cc's auto-link on Android when `static-stdcxx` is set. The explicit Apple `println` stays, because cmake-built llama/ggml still need libc++ when those wrappers are not compiled.

`cc::Build` with `cpp(true)` already emits `cargo:rustc-link-lib=c++` on Apple. `build.rs` also printed that flag in the Apple linker block, so rustc got `-lc++` twice. That is #979; jimsheen traced it, and it still happens on current main (two identical `cargo:rustc-link-lib=c++` lines in the build-script output). MarcusDunn: "the fix would be welcome."

## What I chose and the alternative

Suppress cc's automatic stdlib on all Apple targets (`TargetOs::Apple`), at both `cc::Build` sites, and keep the explicit `println!("cargo:rustc-link-lib=c++")`. Alternative: `#[cfg(target_os = "macos")]` as in the issue snippet, or drop the explicit println and let cc own the link.

This build script already branches on parsed `TARGET`, not host `cfg`; host cfg would miss Apple cross-compiles, and iOS/watchOS share the same explicit `c++` println. The explicit println is the only libc++ link when `common` and `mtmd` are both off.

Can also suppress cc's `stdc++` on Linux (cc plus `dylib=stdc++` today), or limit the guard to macOS.

## Test plan

- [x] On macOS, `cargo test -p llama-cpp-sys-2 tests::cxx_stdlib_link_directive_is_not_duplicated` fails without the `build.rs` change (count 2) and passes with it (count 1)
- [x] Same test with `--features mtmd` still passes (still exactly one `c++` link directive)
- [ ] Ubuntu CI `cargo test --features sampler,mtmd,llguidance` (the `== 1` assertion is macOS-only; `<= 1` still runs)
- [ ] macOS CI `cargo build --features sampler,mtmd,llguidance`

Fixes #979
